### PR TITLE
load keycloak@1.7.0 from bower instead of including it

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -154,9 +154,9 @@
 <script src="bower_components/google-code-prettify/bin/prettify.min.js"></script>
 <script src="bower_components/zeroclipboard/dist/ZeroClipboard.min.js"></script>
 <script src="bower_components/ng-clip/src/ngClip.js"></script>
-<!-- endbuild -->
 
-<script src="/auth/js/keycloak.js"></script>
+<script src="bower_components/keycloak/dist/keycloak.js"></script>
+<!-- endbuild -->
 
 <!-- build:js({.tmp,app}) scripts/scripts.js -->
 <script src="scripts/app.js"></script>

--- a/bower.json
+++ b/bower.json
@@ -17,7 +17,8 @@
     "ng-idle": "1.0.4",
     "google-code-prettify": "1.0.4",
     "ng-clip": "0.2.6",
-    "angular-c3": "0.0.7"
+    "angular-c3": "0.0.7",
+    "keycloak": "1.7.0"
   },
   "devDependencies": {
     "angular-mocks": "1.4.0",


### PR DESCRIPTION
@matzew i'm using bower here since all the "UI" dependencies are still using it.

i've also used 1.7.0 of keycloak,  not sure if htat should be a later version