### PR TITLE
🐛 Update the example Android code for FCM

### DIFF
--- a/app/snippets/register-device/android.java
+++ b/app/snippets/register-device/android.java
@@ -6,22 +6,26 @@ import android.app.Application;
 import org.jboss.aerogear.android.core.Callback;
 import org.jboss.aerogear.android.unifiedpush.PushRegistrar;
 import org.jboss.aerogear.android.unifiedpush.RegistrarManager;
-import org.jboss.aerogear.android.unifiedpush.gcm.AeroGearGCMPushConfiguration;
+import org.jboss.aerogear.android.unifiedpush.fcm.AeroGearFCMPushConfiguration;
+
+import java.net.URI;
 
 public class PushApplication extends Application {
 
     private final String VARIANT_ID       = "{{ variant.variantID }}";
     private final String SECRET           = "{{ variant.secret }}";
-    private final String GCM_SENDER_ID    = {{ variant.projectNumber ? '"' + variant.projectNumber + '";': '""; // getString(R.string.gcm_defaultSenderId)'}}
+    private final String FCM_SENDER_ID    = {{ variant.projectNumber ? '"' + variant.projectNumber + '";': '""; // getString(R.string.gcm_defaultSenderId)'}}
     private final String UNIFIED_PUSH_URL = "{{ contextPath }}";
+
+    private final String TAG = "ups";
 
     @Override
     public void onCreate() {
         super.onCreate();
 
-        RegistrarManager.config("register", AeroGearGCMPushConfiguration.class)
+        RegistrarManager.config("register", AeroGearFCMPushConfiguration.class)
                     .setPushServerURI(URI.create(UNIFIED_PUSH_URL))
-                    .setSenderIds(GCM_SENDER_ID)
+                    .setSenderId(FCM_SENDER_ID)
                     .setVariantID(VARIANT_ID)
                     .setSecret(SECRET)
                     .asRegistrar();


### PR DESCRIPTION
* use the AeroGearFCMPushConfiguration class
* use FCM_SENDER_ID final
* update & add missing imports
* fix method name for setting sender id

These changes are based on trying to use the below sample code shown in the UI
![image](https://user-images.githubusercontent.com/878251/37121870-61a973ce-2256-11e8-9d7e-bf2422f960ff.png)
