### PR TITLE
bugfix: variant tabs were accidentally hidden

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ dist
 app/bower-components
 app/bower_components
 npm-debug.log
+local-config.json

--- a/app/index.html
+++ b/app/index.html
@@ -80,7 +80,7 @@
     </a>
   </div>
   <div class="collapse navbar-collapse navbar-collapse-1">
-    <ul class="nav navbar-nav navbar-utility">
+    <ul class="nav navbar-nav navbar-utility user-dropdown">
       <li class="dropdown" dropdown ng-if="app.warnings.length">
         <a href dropdown-toggle>
           <span class="pficon pficon-info"></span>

--- a/app/styles/main.less
+++ b/app/styles/main.less
@@ -779,6 +779,6 @@ li.L9 {
 }
 
 // Hide the user menu
-ul.nav {
+ul.user-dropdown {
    display: none;
 }


### PR DESCRIPTION
The change to  hide the user dropdown did accidentally also hide the variant tabs.

Verification:

1. Run the Admin UI locally from this branch against a UPS instance
1. Create a push application and a variant
1. Open the variant. You should see the tabs (Analytics, Sender API...) but not the user dropdown

![bildschirmfoto 2018-04-05 um 12 50 56](https://user-images.githubusercontent.com/1851198/38362162-236e245c-38d0-11e8-9485-8dcfbe6db498.png)
