### PR TITLE
allow to directly link to variants

### DIFF
--- a/app/components/app-detail/app-detail.js
+++ b/app/components/app-detail/app-detail.js
@@ -6,6 +6,7 @@ angular.module('upsConsole')
     this.app = null; // is retrieved in canActivate
     this.notifications = null; // is retrieved in canActivate
     this.tab = $routeParams.tab;
+    this.selectedVariant = $routeParams.variant;
 
     this.contextPath = ContextProvider.contextPath();
 
@@ -13,6 +14,14 @@ angular.module('upsConsole')
       return $q.all([
         applicationsEndpoint.getWithMetrics({appId: $routeParams.app})
           .then(function( app ) {
+
+            // Expand the variant if an ID is passed in the URL
+            if (self.selectedVariant && app.variants) {
+              app.variants.forEach(function (variant) {
+                variant.$toggled = self.selectedVariant === variant.variantID;
+              });
+            }
+
             self.app = app;
             if ( !app.variants.length ) {
               self.tab = 'variants';

--- a/app/components/home/home.js
+++ b/app/components/home/home.js
@@ -74,5 +74,4 @@ angular.module('upsConsole')
         }
       });
     };
-
   });

--- a/app/scripts/controllers/AppController.js
+++ b/app/scripts/controllers/AppController.js
@@ -17,7 +17,7 @@
 'use strict';
 
 angular.module('upsConsole')
-  .controller('AppController', function ( $rootScope, $scope, $http, $interval, $timeout, $log, appConfig, dashboardEndpoint, $$rootRouter ) {
+  .controller('AppController', function ( $rootScope, $scope, $http, $interval, $timeout, $log, $location, appConfig, dashboardEndpoint, $$rootRouter ) {
 
     var self = this;
 
@@ -31,7 +31,9 @@ angular.module('upsConsole')
     this.username = getUsername();
     $scope.$watch(getUsername, function( newValue ) {
       self.username = newValue;
-      $$rootRouter.navigate('/');
+      // After the user is resolved, redirect to the URL passed
+      // to the browser
+      $$rootRouter.navigate($location.url());
     });
 
     this.havePendingRequests = function() {

--- a/app/scripts/routes.js
+++ b/app/scripts/routes.js
@@ -12,6 +12,7 @@ angular.module('upsConsole')
       {path: '/wizard/send-push-notification',  component: 'wizard04SendPushNotification'},
       {path: '/wizard/setup-sender',  component: 'wizard05SetupSender'},
       {path: '/wizard/done',          component: 'wizard06Done'},
+      {path: '/app/:app/:tab/:variant', component: 'appDetail'},
       {path: '/app/:app/:tab',        component: 'appDetail'},
       {path: '/links-check',          component: 'linksCheck'},
     ]);


### PR DESCRIPTION
Allow to directly link to variants using the following route patter:

`<base url>/ag-push/#/app/<push app id>/variants/<variant id>`

Verification steps:
1. Set the UI up for local development and checkout this branch
1. Create a push application and two variants
1. Copy the URL from the browser and add the variant ID of one one the variants
1. Open this new URL in a new tab
1. You should see the variant details page with one of the variants expanded

@cfoskin