### PR TITLE
Unify admin ui

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ dist
 app/bower-components
 app/bower_components
 npm-debug.log
+local-config.json

--- a/app/index.html
+++ b/app/index.html
@@ -85,7 +85,7 @@
     </a>
   </div>
   <div class="collapse navbar-collapse navbar-collapse-1">
-    <ul class="nav navbar-nav navbar-utility">
+    <ul ng-show="showUserDropdown" class="nav navbar-nav navbar-utility">
       <li class="dropdown" dropdown ng-if="app.warnings.length">
         <a href dropdown-toggle>
           <span class="pficon pficon-info"></span>

--- a/app/scripts/controllers/AppController.js
+++ b/app/scripts/controllers/AppController.js
@@ -17,7 +17,7 @@
 'use strict';
 
 angular.module('upsConsole')
-  .controller('AppController', function ( $rootScope, $scope, Auth, $http, $interval, $timeout, $log, appConfig, dashboardEndpoint, $$rootRouter ) {
+  .controller('AppController', function ( $rootScope, $scope, $location, Auth, $http, $interval, $timeout, $log, appConfig, dashboardEndpoint, $$rootRouter ) {
 
     var self = this;
 
@@ -26,12 +26,21 @@ angular.module('upsConsole')
 
     //Retrieve the current logged in username
     function getUsername() {
-      return Auth.keycloak.idTokenParsed.preferred_username;
+      if (Auth && Auth.keycloak) {
+        $rootScope.showUserDropdown = true;
+        return Auth.keycloak.idTokenParsed.preferred_username;
+      } else {
+        $rootScope.showUserDropdown = false;
+        return 'dummy';
+      }
     }
+
     this.username = getUsername();
     $scope.$watch(getUsername, function( newValue ) {
       self.username = newValue;
-      $$rootRouter.navigate('/');
+      // After the user is resolved, redirect to the URL passed
+      // to the browser
+      $$rootRouter.navigate($location.url());
     });
 
     this.logout = function() {

--- a/app/scripts/controllers/IdleController.js
+++ b/app/scripts/controllers/IdleController.js
@@ -1,54 +1,59 @@
 'use strict';
 
 angular.module('upsConsole')
-  .controller('IdleController', function(Keepalive, Idle, $rootScope, $scope, $log, appConfig, Auth) {
+  .controller('IdleController', function (Keepalive, Idle, $rootScope, $scope, $log, appConfig, Auth) {
 
     var self = this;
 
     self.config = appConfig;
+
+    // No need for idling when no authentication is used
+    if (Auth && Auth.keycloak) {
+      Idle.watch();
+    }
+
     /**
      * idle service, keepalive, auth token refresh
      */
-    Idle.watch();
     self.idleCountdown = appConfig.idleWarningDuration + 1;
-    $rootScope.$on('KeepaliveResponse', function() {
-      Auth.keycloak.updateToken(45).success(function(refreshed) {
+    $rootScope.$on('KeepaliveResponse', function () {
+      Auth.keycloak.updateToken(45).success(function (refreshed) {
         if (refreshed) {
           $log.debug('token was successfully refreshed');
         } else {
           $log.debug('token is still valid');
         }
-      }).error(function() {
+      }).error(function () {
         $log.debug('failed to refresh the token, or the session has expired');
       });
     });
 
-    $rootScope.$on('IdleStart', function() {
+    $rootScope.$on('IdleStart', function () {
       $log.debug('idleStart');
 
     });
-    $rootScope.$on('IdleWarn', function() {
+    $rootScope.$on('IdleWarn', function () {
       $log.debug('idleWarn');
-      $scope.$apply(function() {
+      $scope.$apply(function () {
         self.idleCountdown = self.idleCountdown - 1;
       });
     });
-    $rootScope.$on('IdleEnd', function() {
+    $rootScope.$on('IdleEnd', function () {
       $log.debug('idleEnd');
-      $scope.$apply(function() {
+      $scope.$apply(function () {
         self.idleCountdown = appConfig.idleWarningDuration + 1;
       });
 
     });
-    $rootScope.$on('IdleTimeout', function() {
+    $rootScope.$on('IdleTimeout', function () {
       $log.debug('idleTimeout');
       Auth.logout();
     });
   })
 
-  .config( function( KeepaliveProvider, IdleProvider, appConfigProvider ) {
+  .config(function (KeepaliveProvider, IdleProvider, appConfigProvider) {
     var appConfig = appConfigProvider.$get();
-    IdleProvider.idle( appConfig.idleDuration );
-    IdleProvider.timeout( appConfig.idleWarningDuration );
-    KeepaliveProvider.interval( appConfig.keepaliveInterval );
+    IdleProvider.idle(appConfig.idleDuration);
+    IdleProvider.timeout(appConfig.idleWarningDuration);
+    KeepaliveProvider.interval(appConfig.keepaliveInterval);
   });

--- a/app/scripts/keycloak-init.js
+++ b/app/scripts/keycloak-init.js
@@ -6,9 +6,13 @@
    */
   var auth = {};
   var app = angular.module('upsConsole');
+  var AUTH_CONFIG_PATH = 'rest/auth/config';
 
   function initKeycloak() {
-    var keycloak = new Keycloak('rest/keycloak/config');
+    // Ideally we would use the config object retrieved by the fetch call
+    // This should work and is described in the keycloak.js documentation
+    // but triggers an error here. Possibly a bug in keycloak.js
+    var keycloak = new Keycloak(AUTH_CONFIG_PATH);
     auth.loggedIn = false;
     keycloak.init({onLoad: 'login-required'}).success(function () {
       auth.loggedIn = true;
@@ -37,6 +41,8 @@
         request: function (config) {
           var deferred = $q.defer();
 
+          // Those endpoints are never protected on the server regardless of the
+          // auth library in use
           if (config.url === 'rest/sender' || config.url === 'rest/registry/device/importer') {
             return config;
           }
@@ -62,7 +68,7 @@
   }
 
   angular.element(document).ready(function () {
-    fetch('rest/keycloak/config').then(function (response) {
+    fetch(AUTH_CONFIG_PATH).then(function (response) {
       return response.json();
     }).then(function (config) {
       if (config['auth-enabled']) {

--- a/app/scripts/keycloak-init.js
+++ b/app/scripts/keycloak-init.js
@@ -7,14 +7,13 @@
   var auth = {};
   var app = angular.module('upsConsole');
 
-  angular.element(document).ready(function () {
+  function initKeycloak() {
     var keycloak = new Keycloak('rest/keycloak/config');
     auth.loggedIn = false;
-
-    keycloak.init({ onLoad: 'login-required' }).success(function () {
+    keycloak.init({onLoad: 'login-required'}).success(function () {
       auth.loggedIn = true;
       auth.keycloak = keycloak;
-      auth.logout = function() {
+      auth.logout = function () {
         auth.loggedIn = false;
         auth.keycloak = null;
         window.location = keycloak.createLogoutUrl();
@@ -26,39 +25,61 @@
     }).error(function () {
       window.location.reload();
     });
+  }
 
-  });
+  function configureAuth() {
+    app.factory('Auth', function () {
+      return auth;
+    });
 
-  app.factory('Auth', function () {
-    return auth;
-  });
+    app.factory('authInterceptor', function ($q, Auth) {
+      return {
+        request: function (config) {
+          var deferred = $q.defer();
 
-  app.factory('authInterceptor', function ($q, Auth) {
-    return {
-      request: function (config) {
-        var deferred = $q.defer();
+          if (config.url === 'rest/sender' || config.url === 'rest/registry/device/importer') {
+            return config;
+          }
 
-        if (config.url === 'rest/sender' || config.url === 'rest/registry/device/importer') {
-          return config;
+          if (Auth.keycloak && Auth.keycloak.token) {
+            Auth.keycloak.updateToken(5).success(function () {
+              config.headers = config.headers || {};
+              config.headers.Authorization = 'Bearer ' + Auth.keycloak.token;
+
+              deferred.resolve(config);
+            }).error(function () {
+              window.location.reload();
+            });
+          }
+          return deferred.promise;
         }
+      };
+    });
 
-        if (Auth.keycloak && Auth.keycloak.token) {
-          Auth.keycloak.updateToken(5).success(function () {
-            config.headers = config.headers || {};
-            config.headers.Authorization = 'Bearer ' + Auth.keycloak.token;
+    app.config(function ($httpProvider) {
+      $httpProvider.interceptors.push('authInterceptor');
+    });
+  }
 
-            deferred.resolve(config);
-          }).error(function () {
-            window.location.reload();
-          });
-        }
-        return deferred.promise;
+  angular.element(document).ready(function () {
+    fetch('rest/keycloak/config').then(function (response) {
+      return response.json();
+    }).then(function (config) {
+      if (config['auth-enabled']) {
+        initKeycloak();
+        configureAuth();
+      } else {
+        // Auth disabled on the server
+        // Default to logged in and do nothing on logout
+        app.factory('Auth', function () {
+          auth.loggedIn = true;
+          auth.logout = function () {
+          };
+          return auth;
+        });
+
+        angular.bootstrap(document, ['upsConsole']);
       }
-    };
+    });
   });
-
-  app.config(function ($httpProvider) {
-    $httpProvider.interceptors.push('authInterceptor');
-  });
-
 })();

--- a/app/scripts/routes.js
+++ b/app/scripts/routes.js
@@ -12,6 +12,7 @@ angular.module('upsConsole')
       {path: '/wizard/send-push-notification',  component: 'wizard04SendPushNotification'},
       {path: '/wizard/setup-sender',  component: 'wizard05SetupSender'},
       {path: '/wizard/done',          component: 'wizard06Done'},
+      {path: '/app/:app/:tab/:variant', component: 'appDetail'},
       {path: '/app/:app/:tab',        component: 'appDetail'},
       {path: '/links-check',          component: 'linksCheck'},
     ]);


### PR DESCRIPTION
Makes the UI work with or without authentication (keycloak). Also adds a new route that allows opening a single variant.

## Verification steps

1. Must be tested together with: https://github.com/aerogear/aerogear-unifiedpush-server/pull/984
1. Build the admin UI from this branch
```
$ mvn clean install
```
1. Build UPS from the `unify-admin-ui` branch and start the auth-less image:
```
$ mvn clean install -DskipTests
$ docker run -p 8080:8080 -it aerogear/ups:plain
```
1. Go to localhost:8080. You should go straight to UPS, no login.
1. Create a push application and two variants.
1. Now open the variants view.
1. Copy one of the variant IDs and create a URL like:
```
http://localhost:8080/#/app/<push app id>/variants/<variant ID>
```
1. Open the URL in a new tab: the selected variant should be expanded
1. Stop the image and start the one with keycloak:
```
docker run -p 8080:8080 -it aerogear/ups:kc
```
1. This time a login must be required. Repeat the same verification steps.

ping @cfoskin