### PR TITLE
Add break-word for google-key

### DIFF
--- a/app/styles/main.less
+++ b/app/styles/main.less
@@ -775,3 +775,7 @@ li.L9 {
     }
   }
 }
+
+dd.google-key.ng-binding {
+  overflow-wrap: break-word;
+}


### PR DESCRIPTION
| Before | After |
|:-:|:-:|
| <img width="1072" alt="ups-before" src="https://user-images.githubusercontent.com/13337/64652930-6ec27300-d3fb-11e9-922d-77943f78c89b.png"> | <img width="1028" alt="ups-after" src="https://user-images.githubusercontent.com/13337/64652929-6ec27300-d3fb-11e9-9bf1-21641036c198.png"> |

