### PR TITLE
feat(applications): added the sender API panel

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,9 +5,9 @@
   "requires": true,
   "dependencies": {
     "@aerogear/unifiedpush-admin-client": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/@aerogear/unifiedpush-admin-client/-/unifiedpush-admin-client-4.0.2.tgz",
-      "integrity": "sha512-6hnEn/+XW9sQPgcd0eLnb5C+RjZQI0MT/L2uj77QELxjrTDBwLnOzN7OsY65MjxYUzis2ZzoFSu80mWv7nn4hQ==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@aerogear/unifiedpush-admin-client/-/unifiedpush-admin-client-4.1.0.tgz",
+      "integrity": "sha512-8bSaV29ZcOVeDLs9Ny3X4Wvnnpb0FHofs8lcXBG30fhP35Re82G3vezIh4K2ET3MHHTBlBrHizejUURoDxNwyQ==",
       "requires": {
         "axios": "0.19.2",
         "form-data": "3.0.0"

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
-    "@aerogear/unifiedpush-admin-client": "4.0.2",
+    "@aerogear/unifiedpush-admin-client": "4.1.0",
     "@fortawesome/fontawesome-free": "^5.13.0",
     "@patternfly/react-core": "4.18.5",
     "@types/react-syntax-highlighter": "^11.0.4",

--- a/src/application/ApplicationDetail/ApplicationDetail.tsx
+++ b/src/application/ApplicationDetail/ApplicationDetail.tsx
@@ -3,6 +3,7 @@ import { PushApplication } from '@aerogear/unifiedpush-admin-client';
 import { NoVariantsPanel } from './panels/NoVariantsPanel';
 import { Modal, Tabs, Tab } from '@patternfly/react-core';
 import { VariantsPanel } from './panels/VariantsPanel';
+import { SenderAPI } from './SenderAPI';
 
 interface Props {
   app?: PushApplication;
@@ -10,30 +11,48 @@ interface Props {
   onClose: (app: PushApplication) => void;
 }
 
-export class ApplicationDetail extends Component<Props> {
-  render = () => (
-    <Modal
-      title={this.props.app?.name || ''}
-      isOpen={this.props.show}
-      onClose={() => this.props.onClose && this.props.onClose(this.props.app!)}
-      // actions={[
-      //     <Button key="confirm" variant="primary" onClick={this.handleModalToggle}>
-      //         Confirm
-      //     </Button>,
-      //     <Button key="cancel" variant="link" onClick={this.handleModalToggle}>
-      //         Cancel
-      //     </Button>
-      // ]}
-    >
-      <Tabs activeKey={0} isBox={true}>
-        <Tab eventKey={0} title="Variants">
-          <NoVariantsPanel app={this.props.app} />
-          <VariantsPanel app={this.props.app} variantType="android" />
-          <VariantsPanel app={this.props.app} variantType="ios" />
-          <VariantsPanel app={this.props.app} variantType="ios_token" />
-          <VariantsPanel app={this.props.app} variantType="web_push" />
-        </Tab>
-      </Tabs>
-    </Modal>
-  );
+interface State {
+  activeTab: number;
+}
+
+export class ApplicationDetail extends Component<Props, State> {
+  constructor(props: Props) {
+    super(props);
+    this.state = {
+      activeTab: 0,
+    };
+  }
+
+  render = () => {
+    const onTabSelect = (tabKey: number) => {
+      this.setState({ activeTab: tabKey });
+    };
+
+    return (
+      <Modal
+        title={this.props.app?.name || ''}
+        isOpen={this.props.show}
+        onClose={() =>
+          this.props.onClose && this.props.onClose(this.props.app!)
+        }
+      >
+        <Tabs
+          activeKey={this.state.activeTab}
+          isBox={true}
+          onSelect={(evt, key) => onTabSelect(key as number)}
+        >
+          <Tab eventKey={0} title="Variants">
+            <NoVariantsPanel app={this.props.app} />
+            <VariantsPanel app={this.props.app} variantType="android" />
+            <VariantsPanel app={this.props.app} variantType="ios" />
+            <VariantsPanel app={this.props.app} variantType="ios_token" />
+            <VariantsPanel app={this.props.app} variantType="web_push" />
+          </Tab>
+          <Tab eventKey={1} title="Sender API">
+            <SenderAPI app={this.props.app!} />
+          </Tab>
+        </Tabs>
+      </Modal>
+    );
+  };
 }

--- a/src/application/ApplicationDetail/CodeSnippet.tsx
+++ b/src/application/ApplicationDetail/CodeSnippet.tsx
@@ -1,15 +1,17 @@
 import React, { Component } from 'react';
 import SyntaxHighlighter from 'react-syntax-highlighter';
 import { docco } from 'react-syntax-highlighter/dist/esm/styles/hljs';
-import { UpsClientFactory } from '../../../utils/UpsClientFactory';
+import { UpsClientFactory } from '../../utils/UpsClientFactory';
 import {
   AndroidVariant,
+  PushApplication,
   Variant,
   WebPushVariant,
 } from '@aerogear/unifiedpush-admin-client';
 
 interface Props {
-  variant: Variant;
+  variant?: Variant;
+  app?: PushApplication;
   language: string;
   snippet: string;
   maxHeight?: number;
@@ -26,15 +28,20 @@ export class CodeSnippet extends Component<Props> {
   readonly render = () => {
     const replacePlaceHolders = (template: string) =>
       template
-        .replace('__VARIANTID__', this.props.variant.variantID!)
-        .replace('__VARIANT_SECRET__', this.props.variant.secret!)
+        .replace(
+          '__PUSHAPPLICATIONID__',
+          this.props.app?.pushApplicationID ?? ''
+        )
+        .replace('__MASTERSECRET__', this.props.app?.masterSecret ?? '')
+        .replace('__VARIANTID__', this.props.variant?.variantID ?? '')
+        .replace('__VARIANT_SECRET__', this.props.variant?.secret ?? '')
         .replace(
           '__VAPID_PUBLIC_KEY__',
-          (this.props.variant as WebPushVariant).publicKey || ''
+          (this.props.variant as WebPushVariant)?.publicKey || ''
         )
         .replace(
           '__SENDERID__',
-          (this.props.variant as AndroidVariant).projectNumber || ''
+          (this.props.variant as AndroidVariant)?.projectNumber || ''
         )
         .replace('__SERVERURL__', UpsClientFactory.getUPSServerURL());
 

--- a/src/application/ApplicationDetail/SenderAPI.tsx
+++ b/src/application/ApplicationDetail/SenderAPI.tsx
@@ -1,0 +1,192 @@
+import React, { Component } from 'react';
+import { PushApplication, Variant } from '@aerogear/unifiedpush-admin-client';
+import { Title } from '../../common/Title';
+import {
+  Alert,
+  Button,
+  ButtonVariant,
+  Label,
+  Tab,
+  Tabs,
+  Text,
+  TextContent,
+  TextList,
+  TextListItem,
+  TextListItemVariants,
+  TextListVariants,
+} from '@patternfly/react-core';
+import { RedoIcon } from '@patternfly/react-icons';
+import { UpsClientFactory } from '../../utils/UpsClientFactory';
+import { RenewApplicationSecret } from './panels/dialogs/RenewApplicationSecret';
+import { CodeSnippet } from './CodeSnippet';
+import { snippet as java_snippet } from './snippets/sender/java';
+import { snippet as node_snippet } from './snippets/sender/node';
+import { snippet as curl_snippet } from './snippets/sender/curl';
+import { links } from '../../links';
+
+interface State {
+  refreshSecret: boolean;
+  activeTab: string;
+}
+interface Props {
+  app: PushApplication;
+}
+export class SenderAPI extends Component<Props, State> {
+  constructor(props: Props) {
+    super(props);
+    this.state = {
+      refreshSecret: false,
+      activeTab: 'java-sender-api',
+    };
+  }
+
+  readonly render = () => {
+    const onRefreshed = (app: PushApplication) => {
+      this.props.app.masterSecret = app.masterSecret;
+      this.setState({ refreshSecret: false });
+    };
+
+    const onTabSelect = (tabKey: string) => {
+      this.setState({ activeTab: tabKey });
+    };
+
+    return (
+      <>
+        <RenewApplicationSecret
+          visible={this.state.refreshSecret}
+          app={this.props.app}
+          onCancel={() => this.setState({ refreshSecret: false })}
+          onRefreshed={onRefreshed}
+        />
+        <Title>Sending push notifications</Title>
+        <Text component={'small'}>
+          Make your backend server send push notifications through this
+          UnifiedPush Server using supported sender APIs.
+        </Text>
+        <TextContent style={{ marginTop: 20, marginBottom: 20 }}>
+          <TextList component={TextListVariants.dl}>
+            <TextListItem component={TextListItemVariants.dt}>
+              Server URL:
+            </TextListItem>
+            <TextListItem component={TextListItemVariants.dd}>
+              {UpsClientFactory.getUPSServerURL()}
+            </TextListItem>
+            <TextListItem component={TextListItemVariants.dt}>
+              Application ID:
+            </TextListItem>
+            <TextListItem component={TextListItemVariants.dd}>
+              {this.props.app.pushApplicationID}
+            </TextListItem>
+            <TextListItem component={TextListItemVariants.dt}>
+              Master Secret:
+            </TextListItem>
+            <TextListItem component={TextListItemVariants.dd}>
+              {this.props.app.masterSecret}
+            </TextListItem>
+
+            <TextListItem component={TextListItemVariants.dd}>
+              <Button
+                className={'button-small'}
+                icon={<RedoIcon />}
+                variant={ButtonVariant.secondary}
+                onClick={() => this.setState({ refreshSecret: true })}
+              >
+                Renew Master Secret
+              </Button>
+            </TextListItem>
+          </TextList>
+        </TextContent>
+        <Alert variant="warning" title="Keep this info secure!">
+          Never expose your Master Secret or Application ID publicly.
+        </Alert>
+        <Tabs
+          style={{ marginTop: 20 }}
+          activeKey={this.state.activeTab}
+          isBox={false}
+          onSelect={(evt, key) => onTabSelect(key as string)}
+        >
+          <Tab eventKey={'java-sender-api'} title="Java Sender API">
+            <Title headingLevel={'h1'}>Set up Java UPS Sender API</Title>
+            <Text component={'small'}>
+              First add{' '}
+              <code className={'code'}>unifiedpush-java-client.jar</code> as a{' '}
+              <a href={'links.pushApplications.senderAPI.docs.java_client'}>
+                dependency to your Java project
+              </a>
+              .
+              <p>
+                Then use the following snippet in your Java code to enable push
+                notification sending.
+              </p>
+            </Text>
+            <CodeSnippet
+              app={this.props.app}
+              language={'java'}
+              snippet={java_snippet}
+            />
+            <Text component={'small'}>
+              Read more on the details of the{' '}
+              <a href={links.pushApplications.senderAPI.docs.java_client}>
+                Java UPS Sender API in documentation
+              </a>
+              .
+              <p>
+                If you have questions about this process,{' '}
+                <a href={'links.pushApplications.senderAPI.docs.java_client'}>
+                  visit the documentation for full step by step explanation
+                </a>
+                .
+              </p>
+            </Text>
+          </Tab>
+          <Tab eventKey={'node-sender-api'} title="Node.js Sender API">
+            <Title headingLevel={'h1'}>Set up Node.js Sender API</Title>
+            <Text component={'small'}>
+              First add <code className={'code'}>unifiedpush-jnode-sender</code>{' '}
+              as a{' '}
+              <a href={links.pushApplications.senderAPI.docs.node_client}>
+                dependency to your project
+              </a>
+              .
+              <p>
+                Then use the following snippet in your Node.js code to enable
+                push notification sending.
+              </p>
+            </Text>
+            <CodeSnippet
+              app={this.props.app}
+              language={'javascript'}
+              snippet={node_snippet}
+            />
+            <Text component={'small'}>
+              Read more on the details of the{' '}
+              <a href={links.pushApplications.senderAPI.docs.node_client}>
+                Node.js UPS Sender API in documentation
+              </a>
+              .
+            </Text>
+          </Tab>
+          <Tab eventKey={'rest-sender-api'} title="REST Sender API (with CURL)">
+            <Title headingLevel={'h1'}>
+              Use UPS REST Sender API (with CURL)
+            </Title>
+            <Text component={'small'}>
+              If none of the official client libs suit you or you just want to
+              simply try out the notification sending, you can use the REST API
+              directly.
+              <p>
+                Run the following <code className={'code'}>curl</code> command
+                in a shell to send a notification to UPS server.
+              </p>
+            </Text>
+            <CodeSnippet
+              app={this.props.app}
+              language={'bash'}
+              snippet={curl_snippet}
+            />
+          </Tab>
+        </Tabs>
+      </>
+    );
+  };
+}

--- a/src/application/ApplicationDetail/panels/android/AndroidCodeSnippets.tsx
+++ b/src/application/ApplicationDetail/panels/android/AndroidCodeSnippets.tsx
@@ -1,7 +1,7 @@
 import { PushApplication, Variant } from '@aerogear/unifiedpush-admin-client';
 import React, { Component } from 'react';
 import { Tab, Tabs } from '@patternfly/react-core';
-import { CodeSnippet } from '../CodeSnippet';
+import { CodeSnippet } from '../../CodeSnippet';
 import {
   cordova_snippet_android,
   java_snippet,

--- a/src/application/ApplicationDetail/panels/dialogs/RenewApplicationSecret.tsx
+++ b/src/application/ApplicationDetail/panels/dialogs/RenewApplicationSecret.tsx
@@ -15,9 +15,8 @@ import { UpsClientFactory } from '../../../../utils/UpsClientFactory';
 interface Props {
   visible: boolean;
   app: PushApplication;
-  variant: Variant;
   onCancel: () => void;
-  onRefreshed: (variant: Variant) => void;
+  onRefreshed: (app: PushApplication) => void;
 }
 
 interface State {
@@ -25,7 +24,7 @@ interface State {
   nameValid: ValidatedOptions;
 }
 
-export class RenewVariantSecret extends Component<Props, State> {
+export class RenewApplicationSecret extends Component<Props, State> {
   constructor(props: Props) {
     super(props);
     this.state = {
@@ -49,20 +48,15 @@ export class RenewVariantSecret extends Component<Props, State> {
 
       // make the call
 
-      const variant = await UpsClientFactory.getUpsClient()
-        .variants[this.props.variant.type].renewSecret(
-          this.props.app.pushApplicationID,
-          this.props.variant.variantID
-        )
+      const app = await UpsClientFactory.getUpsClient()
+        .applications.renewSecret(this.props.app.pushApplicationID)
         .execute();
-      console.log({ old: this.props.variant, new: variant });
       await this.setState({ refreshing: false });
-      this.props.onRefreshed(variant);
+      this.props.onRefreshed(app);
     };
 
     const handleAppNameInput = (value: string) => {
-      console.log('verify', value);
-      if (value === this.props.variant.name) {
+      if (value === this.props.app.name) {
         this.setState({ nameValid: ValidatedOptions.success });
       } else {
         this.setState({ nameValid: ValidatedOptions.error });
@@ -73,7 +67,7 @@ export class RenewVariantSecret extends Component<Props, State> {
       <Modal
         variant={ModalVariant.large}
         title="Renew Variant Secret"
-        description={`You are about to change the variant secret for variant "${this.props.variant.name}"!`}
+        description={`You are about to change the master secret for application "${this.props.app.name}"!`}
         isOpen={this.props.visible}
         onClose={this.props.onCancel}
         actions={[
@@ -94,9 +88,8 @@ export class RenewVariantSecret extends Component<Props, State> {
         ]}
       >
         <Text component={TextVariants.small}>
-          Be aware that this cannot be undone and you'll have to change secret
-          on all the installed devices in order to continue receiving push
-          notifications.
+          Be aware that this cannot be undone and you'll have to change your
+          sender in order to continue sending push notifications.
         </Text>
 
         <TextInput
@@ -107,7 +100,7 @@ export class RenewVariantSecret extends Component<Props, State> {
           aria-label="invalid text input example"
         />
         <Text component={TextVariants.small}>
-          Please type in the name of the variant to confirm.
+          Please type in the name of the application to confirm.
         </Text>
       </Modal>
     );

--- a/src/application/ApplicationDetail/panels/ios_cert/iOSCertCodeSnippets.tsx
+++ b/src/application/ApplicationDetail/panels/ios_cert/iOSCertCodeSnippets.tsx
@@ -1,7 +1,7 @@
 import { PushApplication, Variant } from '@aerogear/unifiedpush-admin-client';
 import React, { Component } from 'react';
 import { Tab, Tabs } from '@patternfly/react-core';
-import { CodeSnippet } from '../CodeSnippet';
+import { CodeSnippet } from '../../CodeSnippet';
 import {
   cordova_snippet_ios,
   ios_snippet,

--- a/src/application/ApplicationDetail/panels/ios_token/iOSTokenCodeSnippets.tsx
+++ b/src/application/ApplicationDetail/panels/ios_token/iOSTokenCodeSnippets.tsx
@@ -1,7 +1,7 @@
 import { PushApplication, Variant } from '@aerogear/unifiedpush-admin-client';
 import React, { Component } from 'react';
 import { Tab, Tabs } from '@patternfly/react-core';
-import { CodeSnippet } from '../CodeSnippet';
+import { CodeSnippet } from '../../CodeSnippet';
 import {
   cordova_snippet_ios,
   ios_snippet,

--- a/src/application/ApplicationDetail/panels/web_push/WebPushCodeSnippets.tsx
+++ b/src/application/ApplicationDetail/panels/web_push/WebPushCodeSnippets.tsx
@@ -1,7 +1,7 @@
 import { PushApplication, Variant } from '@aerogear/unifiedpush-admin-client';
 import React, { Component } from 'react';
 import { Tab, Tabs } from '@patternfly/react-core';
-import { CodeSnippet } from '../CodeSnippet';
+import { CodeSnippet } from '../../CodeSnippet';
 import { push_config_webpush } from '../../snippets';
 
 interface Props {

--- a/src/application/ApplicationDetail/snippets/sender/curl.tsx
+++ b/src/application/ApplicationDetail/snippets/sender/curl.tsx
@@ -1,0 +1,12 @@
+export const snippet = `
+curl -u "__PUSHAPPLICATIONID__:__MASTERSECRET__"  \\
+   -v -H "Accept: application/json" -H "Content-type: application/json"  \\
+   -X POST  -d \\
+  '{
+     "message": {
+      "alert": "Hello from the curl HTTP Sender!",
+      "sound": "default"
+     }
+   }'  \\
+   __SERVERURL__/rest/sender
+`;

--- a/src/application/ApplicationDetail/snippets/sender/java.tsx
+++ b/src/application/ApplicationDetail/snippets/sender/java.tsx
@@ -1,0 +1,17 @@
+export const snippet = `
+final PushSender sender =
+    DefaultPushSender.withRootServerURL("__SERVERURL__")
+        .pushApplicationId("__PUSHAPPLICATIONID__")
+        .masterSecret("__MASTERSECRET__")
+    .build();
+
+final UnifiedMessage unifiedMessage = UnifiedMessage.
+    withMessage()
+        .alert("Hello from Java Sender API!")
+    .build();
+
+ 
+sender.send(unifiedMessage, () -> {
+    //do cool stuff
+}); 
+`;

--- a/src/application/ApplicationDetail/snippets/sender/node.tsx
+++ b/src/application/ApplicationDetail/snippets/sender/node.tsx
@@ -1,0 +1,27 @@
+export const snippet = `
+const agSender = require('unifiedpush-node-sender');
+
+const settings = {
+  url: "__SERVERURL__",
+  applicationId: "__PUSHAPPLICATIONID__",
+  masterSecret: "__MASTERSECRET__"
+};
+
+const message = {
+  alert: "Hello from the Node.js Sender API!"
+};
+
+const options = {
+  config: {
+    ttl: 3600
+  }
+};
+
+agSender(settings).then((client) => {
+  client.sender.send(message, options).then((response) => {
+    console.log('success', response);
+  }).catch((error) => {
+    console.log('error', error);
+  })
+});
+`;

--- a/src/application/ApplicationList/ApplicationListItem.tsx
+++ b/src/application/ApplicationList/ApplicationListItem.tsx
@@ -16,6 +16,7 @@ import { Label } from '../../common/Label';
 import {
   EditIcon,
   MessagesIcon,
+  MobileAltIcon,
   TrashIcon,
   UserIcon,
 } from '@patternfly/react-icons';
@@ -42,7 +43,7 @@ export class ApplicationListItem extends Component<Props> {
               <div className={'app-icon'}>{this.props.app.name.charAt(0)}</div>
             </DataListCell>,
             <DataListCell key="primary content" width={5}>
-              <Text component={TextVariants.h1}>{this.props.app.name}</Text>
+              <Text component={TextVariants.h2}>{this.props.app.name}</Text>
               <List variant={ListVariant.inline} className={'subtitle'}>
                 <ListItem>
                   <Label
@@ -64,7 +65,10 @@ export class ApplicationListItem extends Component<Props> {
                   <Label text={'0 messages sent'} icon={<MessagesIcon />} />
                 </ListItem>
                 <ListItem>
-                  <Label text={'0 devices registered'} icon={'fa fa-mobile'} />
+                  <Label
+                    text={'0 devices registered'}
+                    icon={<MobileAltIcon />}
+                  />
                 </ListItem>
               </List>
             </DataListCell>,

--- a/src/common/Title.tsx
+++ b/src/common/Title.tsx
@@ -1,0 +1,20 @@
+import React, { Component } from 'react';
+import { Title as PFTitle } from '@patternfly/react-core';
+
+interface Props {
+  headingLevel?: 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6';
+}
+
+export class Title extends Component<Props> {
+  readonly render = () => {
+    return (
+      <PFTitle
+        className={'ups-title-h3'}
+        headingLevel={this.props.headingLevel ?? 'h3'}
+        size={'md'}
+      >
+        {this.props.children}
+      </PFTitle>
+    );
+  };
+}

--- a/src/links.ts
+++ b/src/links.ts
@@ -18,5 +18,15 @@ export const links = {
         },
       },
     },
+    senderAPI: {
+      docs: {
+        java_client:
+          'http://aerogear.github.io/aerogear-unifiedpush-server/docs/server_sdk/javasender',
+        javadoc:
+          'https://aerogear.org/docs/specs/aerogear-unifiedpush-java-client/',
+        node_client:
+          'http://aerogear.github.io/aerogear-unifiedpush-server/docs/server_sdk/nodesender',
+      },
+    },
   },
 };

--- a/src/styles/App.scss
+++ b/src/styles/App.scss
@@ -1,9 +1,14 @@
+@import url('https://fonts.googleapis.com/css?family=Open+Sans');
 @import 'app-dashboard.scss';
 @import 'landing-page.scss';
 @import 'app-list.scss';
 @import 'globals.scss' ;
 @import 'app-details.scss';
 @import 'variant-forms.scss';
+
+body {
+  color: #333;
+}
 
 :root {
   --pf-global--FontSize--4xl: 2.25rem;
@@ -15,14 +20,27 @@
   --pf-global--FontSize--sm: 0.875rem;
   --pf-global--FontSize--xs: 0.75rem;
 
-  --pf-global--Color--dark-100: rgb(85,85,85);
+  --pf-global--Color--dark-100: #333;
   --pf-global--FontFamily--sans-serif: "Open Sans",Helvetica,Arial,sans-serif;
+
+
 }
+
+.pf-c-label {
+  --pf-c-label--FontSize: 1rem;
+}
+
+.pf-c-content {
+  --pf-c-content--h5--FontSize: 8rem;
+}
+
+
 
 // Buttons
 
 .button-small {
-  font-size: 12px;
+  font-size: 0.7rem;
+  font-weight: bold;
 }
 
 //////////
@@ -72,12 +90,12 @@
 }
 
 h1 {
-  font-size: 24px;
 }
 
 h1, h2 {
   font-weight: 300;
   line-height: 1.1;
+  font-size: 1.4rem;
 }
 
 emptyState {
@@ -105,4 +123,17 @@ emptyState {
 
 .dialogBtn {
   margin-right: 10px;
+}
+
+.ups-title-h3 {
+  margin-top: 20px;
+  margin-bottom: 10px;
+}
+
+.code {
+  padding: 2px 4px;
+  color: #c7254e;
+  background-color: #f9f2f4;
+  border-radius: 1px;
+  box-sizing: border-box;
 }

--- a/src/styles/app-dashboard.css
+++ b/src/styles/app-dashboard.css
@@ -2,7 +2,8 @@
   color: #999; }
 
 .ups-count {
-  font-size: 30px; }
+  font-weight: bold; }
 
 .ups-count-label {
-  font-size: 15px; }
+  font-size: 0.85rem;
+  font-weight: bold; }

--- a/src/styles/app-dashboard.scss
+++ b/src/styles/app-dashboard.scss
@@ -4,10 +4,11 @@
 
 .ups-count {
   @extend %app-dashboard;
-  font-size: 30px;
+  font-weight: bold;
 }
 
 .ups-count-label {
   @extend %app-dashboard;
-  font-size: 15px;
+  font-size: 0.85rem;
+  font-weight: bold;
 }

--- a/src/styles/app-details.scss
+++ b/src/styles/app-details.scss
@@ -8,15 +8,11 @@
 
     .title {
       font-weight: 700;
-      font-size: 16px;
       color: black;
       padding-left: 20px;
       padding-right: 10px;
     }
 
-    .devices {
-      font-size: 16px;
-    }
     .content {
       display:flex;
       align-items:center;

--- a/src/styles/app-list.scss
+++ b/src/styles/app-list.scss
@@ -5,12 +5,12 @@
 
 .subtitle {
   color: #999;
+  font-size: 1rem;
 }
 
 .app-icon {
   background-color: $aerogearBlue;
   color: rgba(255,255,255,.9);
-  font-size: 30px;
   font-weight: bold;
   line-height: 50px;
   text-align: center;

--- a/src/styles/landing-page.scss
+++ b/src/styles/landing-page.scss
@@ -16,7 +16,6 @@
   color: $pureWhite;
   display: inline-block;
   font-weight: bold;
-  font-size: 14px;
   line-height: 34px;
   width: 34px;
 }


### PR DESCRIPTION
## Motivation
https://issues.jboss.org/browse/AEROGEAR-10292

## What
In the sender API details of the app are showed together with instruction on how to send messages using the various clients

![Screenshot 2020-07-17 at 22 04 45](https://user-images.githubusercontent.com/1125019/87826684-9daa4080-c879-11ea-873e-fa5b61eb8fde.png)
![Screenshot 2020-07-17 at 22 04 56](https://user-images.githubusercontent.com/1125019/87826690-9f740400-c879-11ea-958d-a8484c713c53.png)
![Screenshot 2020-07-17 at 22 05 04](https://user-images.githubusercontent.com/1125019/87826692-a00c9a80-c879-11ea-9017-2f6cb862fbf0.png)
