### PR TITLE
refactor: Bumped validator version, cleaned code, removed errors from chrome console

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3224,6 +3224,15 @@
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.1.0.tgz",
       "integrity": "sha512-1Yj8h9Q+QDF5FzhMs/c9+6UntbD5MkRfRwac8DoEm9ZfUBZ7tZ55YcGVAzEe4bXsdQHEk+s9S5wsOKVdZrw0tQ=="
     },
+    "bindings": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+      "optional": true,
+      "requires": {
+        "file-uri-to-path": "1.0.0"
+      }
+    },
     "block-stream": {
       "version": "0.0.9",
       "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.9.tgz",
@@ -6288,6 +6297,12 @@
         "tslib": "^1.9.0"
       }
     },
+    "file-uri-to-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+      "optional": true
+    },
     "filesize": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/filesize/-/filesize-6.0.1.tgz",
@@ -8299,6 +8314,7 @@
           "integrity": "sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==",
           "optional": true,
           "requires": {
+            "bindings": "^1.5.0",
             "nan": "^2.12.1"
           }
         }
@@ -8719,9 +8735,9 @@
       "dev": true
     },
     "json-data-validator": {
-      "version": "0.6.3",
-      "resolved": "https://registry.npmjs.org/json-data-validator/-/json-data-validator-0.6.3.tgz",
-      "integrity": "sha512-ltfIwGkpRjXb+FgNwJBYI3MFEAb9T1uLQIpGaEZgRN27NSOiGE809ObM0LohJIQoZdmMOQbm2CGVks28+6Xt4w==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/json-data-validator/-/json-data-validator-2.1.0.tgz",
+      "integrity": "sha512-X55zTlzlN0RVU5cbqP+kisY3w/3XcqznS58U6FabMbIdHaZ5H3U3pRKYcgUCY7dFjRdFvXsQWS8wY0zcv0ISdQ==",
       "requires": {
         "@types/is-valid-path": "^0.1.0",
         "@types/lodash": "^4.14.146",
@@ -15063,6 +15079,7 @@
           "integrity": "sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==",
           "optional": true,
           "requires": {
+            "bindings": "^1.5.0",
             "nan": "^2.12.1"
           }
         },
@@ -15402,6 +15419,7 @@
           "integrity": "sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==",
           "optional": true,
           "requires": {
+            "bindings": "^1.5.0",
             "nan": "^2.12.1"
           }
         },

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "@patternfly/react-core": "4.18.5",
     "@types/react-syntax-highlighter": "^11.0.4",
     "data-urls": "^2.0.0",
-    "json-data-validator": "^0.6.3",
+    "json-data-validator": "^2.1.0",
     "react": "^16.13.1",
     "react-dom": "^16.13.1",
     "react-scripts": "3.4.1",

--- a/src/application/ApplicationDetail/ApplicationDetail.tsx
+++ b/src/application/ApplicationDetail/ApplicationDetail.tsx
@@ -30,6 +30,7 @@ export class ApplicationDetail extends Component<Props, State> {
 
     return (
       <Modal
+        aria-label={'app-details-modal'}
         title={this.props.app?.name || ''}
         isOpen={this.props.show}
         onClose={() =>

--- a/src/application/ApplicationDetail/SenderAPI.tsx
+++ b/src/application/ApplicationDetail/SenderAPI.tsx
@@ -1,11 +1,10 @@
 import React, { Component } from 'react';
-import { PushApplication, Variant } from '@aerogear/unifiedpush-admin-client';
+import { PushApplication } from '@aerogear/unifiedpush-admin-client';
 import { Title } from '../../common/Title';
 import {
   Alert,
   Button,
   ButtonVariant,
-  Label,
   Tab,
   Tabs,
   Text,

--- a/src/application/ApplicationDetail/panels/FormField.tsx
+++ b/src/application/ApplicationDetail/panels/FormField.tsx
@@ -19,6 +19,7 @@ export class FormField extends Component<Props> {
         return (
           <TextArea
             type="text"
+            id={`ta-${this.props.fieldId}`}
             defaultValue={this.props.defaultValue}
             onChange={this.props.onChange}
             validated={this.props.validated}
@@ -28,6 +29,7 @@ export class FormField extends Component<Props> {
         return (
           <TextInput
             type="text"
+            id={`ti-${this.props.fieldId}`}
             defaultValue={this.props.defaultValue}
             onChange={this.props.onChange}
             validated={this.props.validated}

--- a/src/application/ApplicationDetail/panels/VariantsPanel.tsx
+++ b/src/application/ApplicationDetail/panels/VariantsPanel.tsx
@@ -29,7 +29,6 @@ export abstract class VariantsPanel extends Component<Props> {
       const res = this.props.app.variants.filter(
         (variant: Variant) => variant.type === this.props.variantType
       );
-      console.log({ type: this.props.variantType, res });
       return res;
     }
 
@@ -81,7 +80,11 @@ export abstract class VariantsPanel extends Component<Props> {
           <CardBody>
             <DataList aria-label="Expandable data list example">
               {variants?.map(variant => (
-                <VariantItem variant={variant} app={this.props.app!} />
+                <VariantItem
+                  key={`${variant.variantID}#item`}
+                  variant={variant}
+                  app={this.props.app!}
+                />
               ))}
             </DataList>
           </CardBody>

--- a/src/application/ApplicationDetail/panels/dialogs/RenewApplicationSecret.tsx
+++ b/src/application/ApplicationDetail/panels/dialogs/RenewApplicationSecret.tsx
@@ -1,5 +1,5 @@
 import React, { Component } from 'react';
-import { Variant, PushApplication } from '@aerogear/unifiedpush-admin-client';
+import { PushApplication } from '@aerogear/unifiedpush-admin-client';
 import {
   Button,
   ButtonVariant,

--- a/src/application/ApplicationDetail/panels/ios_cert/iOSCertVariantDetails.tsx
+++ b/src/application/ApplicationDetail/panels/ios_cert/iOSCertVariantDetails.tsx
@@ -1,5 +1,4 @@
 import {
-  IOSTokenVariant,
   IOSVariant,
   PushApplication,
   Variant,

--- a/src/application/ApplicationDetail/panels/ios_token/EditIOSTokenNetworkOptions.tsx
+++ b/src/application/ApplicationDetail/panels/ios_token/EditIOSTokenNetworkOptions.tsx
@@ -13,18 +13,16 @@ import {
   Modal,
   ModalVariant,
   Switch,
-  TextArea,
-  TextInput,
-  ValidatedOptions,
 } from '@patternfly/react-core';
 import { UpsClientFactory } from '../../../../utils/UpsClientFactory';
 import {
   validatorBuilder,
   RuleBuilder,
-  EvaluationResult,
   Data,
   Validator,
 } from 'json-data-validator';
+import { FormField } from '../FormField';
+import { MultiEvaluationResult } from 'json-data-validator/build/src/Rule';
 
 interface Props {
   visible: boolean;
@@ -41,7 +39,7 @@ interface State {
   teamId?: string;
   bundleId?: string;
   production?: boolean;
-  formValidation?: EvaluationResult;
+  formValidation?: MultiEvaluationResult;
 }
 
 export class EditIOSTokenNetworkOptions extends Component<Props, State> {
@@ -88,8 +86,6 @@ export class EditIOSTokenNetworkOptions extends Component<Props, State> {
         .withVariantDefinition(update)
         .execute();
 
-      console.log('updated');
-
       this.props.variant.keyId = this.state.keyId || this.props.variant.keyId;
       this.props.variant.teamId =
         this.state.teamId || this.props.variant.teamId;
@@ -104,40 +100,29 @@ export class EditIOSTokenNetworkOptions extends Component<Props, State> {
     const validator: Validator = validatorBuilder()
       .newRule()
       .withField('keyId')
-      .validate(RuleBuilder.required())
-      .validate(RuleBuilder.length.withLength(10))
+      .validate(RuleBuilder.required().build())
+      .validate(
+        RuleBuilder.length.withLength(
+          10,
+          "Field 'Key ID' must be exactly 10 characters long"
+        )
+      )
       .withField('teamId')
-      .validate(RuleBuilder.required())
-      .validate(RuleBuilder.length.withLength(10))
+      .validate(RuleBuilder.required().build())
+      .validate(
+        RuleBuilder.length.withLength(
+          10,
+          "Field 'Team ID' must be exactly 10 characters long"
+        )
+      )
       .withField('bundleId')
-      .validate(RuleBuilder.matches('^[a-z0-9]+(\\.[a-z0-9]+)+$'))
+      .validate(
+        RuleBuilder.matches(
+          '^[a-z0-9]+(\\.[a-z0-9]+)+$',
+          'The Bundle ID must be a valid URL'
+        )
+      )
       .build();
-
-    const validationState = (field: string) => {
-      const evaluationResult = this.state.formValidation?.details?.find(
-        value => value.field === field
-      );
-      if (evaluationResult?.valid) {
-        console.log('valid');
-        return {
-          valid: true,
-          status: ValidatedOptions.success,
-        };
-      }
-      if (evaluationResult?.valid === false) {
-        console.log('error');
-        return {
-          valid: true,
-          validationResult: evaluationResult,
-          status: ValidatedOptions.error,
-        };
-      }
-      console.log('default');
-      return {
-        valid: true,
-        status: ValidatedOptions.default,
-      };
-    };
 
     const updateField = (name: string, value: string) => {
       this.setState(({
@@ -170,62 +155,71 @@ export class EditIOSTokenNetworkOptions extends Component<Props, State> {
         ]}
       >
         <Form isHorizontal>
-          <FormGroup
-            fieldId={'Push Network'}
+          <FormField
+            component={'textarea'}
+            fieldId={'variant-private-key'}
             label={'Push Network'}
             helperText={'Private Key'}
-          >
-            <TextArea
-              type="text"
-              defaultValue={this.props.variant.privateKey}
-              onChange={value => this.setState({ privateKey: value })}
-            />
-          </FormGroup>
-          <FormGroup
-            fieldId={'Push Network'}
+            helperTextInvalid={
+              this.state.formValidation?.getEvaluationResult('privateKey')
+                ?.message
+            }
+            validated={
+              !this.state.formValidation ||
+              this.state.formValidation.isValid('privateKey')
+                ? 'success'
+                : 'error'
+            }
+            defaultValue={this.props.variant.privateKey}
+            onChange={(value: string) => updateField('privateKey', value)}
+          />
+          <FormField
+            component={'textarea'}
+            fieldId={'variant-key-id'}
             helperText={'Key Id'}
             helperTextInvalid={
-              validationState('keyId').validationResult?.message
+              this.state.formValidation?.getEvaluationResult('keyId')?.message
             }
-            validated={validationState('keyId').status}
-          >
-            <TextInput
-              type="text"
-              defaultValue={this.props.variant.keyId}
-              onChange={(value: string) => updateField('keyId', value)}
-              validated={validationState('keyId').status}
-            />
-          </FormGroup>
-          <FormGroup
-            fieldId={'Push Network'}
+            validated={
+              !this.state.formValidation ||
+              this.state.formValidation.isValid('keyId')
+                ? 'success'
+                : 'error'
+            }
+            defaultValue={this.props.variant.keyId}
+            onChange={(value: string) => updateField('keyId', value)}
+          />
+          <FormField
+            fieldId={'variant-team-id'}
             helperText={'Team Id'}
             helperTextInvalid={
-              validationState('teamId').validationResult?.message
+              this.state.formValidation?.getEvaluationResult('teamId')?.message
             }
-            validated={validationState('teamId').status}
-          >
-            <TextInput
-              type="text"
-              defaultValue={this.props.variant.teamId}
-              onChange={(value: string) => updateField('teamId', value)}
-              validated={validationState('teamId').status}
-            />
-          </FormGroup>
-          <FormGroup
-            fieldId={'Push Network'}
+            validated={
+              !this.state.formValidation ||
+              this.state.formValidation.isValid('teamId')
+                ? 'success'
+                : 'error'
+            }
+            defaultValue={this.props.variant.teamId}
+            onChange={(value: string) => updateField('teamId', value)}
+          />
+          <FormField
+            fieldId={'variant-bundle-id'}
             helperText={'Bundle Id'}
             helperTextInvalid={
-              validationState('bundleId').validationResult?.message
+              this.state.formValidation?.getEvaluationResult('bundleId')
+                ?.message
             }
-            validated={validationState('bundleId').status}
-          >
-            <TextInput
-              type="text"
-              defaultValue={this.props.variant.bundleId}
-              onChange={(value: string) => updateField('bundleId', value)}
-              validated={validationState('bundleId').status}
-            />
-          </FormGroup>
+            validated={
+              !this.state.formValidation ||
+              this.state.formValidation.isValid('bundleId')
+                ? 'success'
+                : 'error'
+            }
+            defaultValue={this.props.variant.bundleId}
+            onChange={(value: string) => updateField('bundleId', value)}
+          />
           <FormGroup fieldId={'Push Network'}>
             <Switch
               id="simple-switch"

--- a/src/application/ApplicationDetail/panels/web_push/EditWebPushNetworkOptions.tsx
+++ b/src/application/ApplicationDetail/panels/web_push/EditWebPushNetworkOptions.tsx
@@ -90,11 +90,11 @@ export class EditWebPushNetworkOptions extends Component<Props, State> {
     const validator: Validator = validatorBuilder()
       .newRule()
       .withField('publicKey')
-      .validate(RuleBuilder.required())
+      .validate(RuleBuilder.required().build())
       .withField('privateKey')
-      .validate(RuleBuilder.required())
+      .validate(RuleBuilder.required().build())
       .withField('alias')
-      .validate(RuleBuilder.required())
+      .validate(RuleBuilder.required().build())
       .build();
 
     const validationState = (field: string) => {

--- a/src/application/ApplicationList/ApplicationList.tsx
+++ b/src/application/ApplicationList/ApplicationList.tsx
@@ -144,6 +144,7 @@ export class ApplicationList extends Component<Props, State> {
                     onEdit={editApp}
                     onDelete={deleteApp}
                     onClick={showAppDetails}
+                    key={`${app.pushApplicationID}#item`}
                   />
                 ))}
               </DataList>

--- a/src/application/VariantForms/AndroidVariantForm.tsx
+++ b/src/application/VariantForms/AndroidVariantForm.tsx
@@ -1,11 +1,7 @@
 import React, { Component } from 'react';
 
 import { TextInput, Button, Form, FormGroup } from '@patternfly/react-core';
-import {
-  AndroidVariant,
-  Variant,
-  PushApplication,
-} from '@aerogear/unifiedpush-admin-client';
+import { AndroidVariant, Variant } from '@aerogear/unifiedpush-admin-client';
 
 interface State {
   serverKey: string;

--- a/src/application/VariantForms/VariantSelectionForm.tsx
+++ b/src/application/VariantForms/VariantSelectionForm.tsx
@@ -10,7 +10,6 @@ import {
 } from '@patternfly/react-core';
 import {
   PushApplication,
-  AndroidVariant,
   AndroidVariantDefinition,
   WebPushVariantDefinition,
   IOSTokenVariantDefinition,

--- a/src/application/crud/CreateVariantPage.tsx
+++ b/src/application/crud/CreateVariantPage.tsx
@@ -1,6 +1,5 @@
 import React, { Component } from 'react';
 import { CodeBranchIcon } from '@patternfly/react-icons';
-import { UpsClientFactory } from '../../utils/UpsClientFactory';
 import {
   EmptyState,
   EmptyStateVariant,
@@ -11,7 +10,6 @@ import {
   Button,
 } from '@patternfly/react-core';
 import { PushApplication } from '@aerogear/unifiedpush-admin-client';
-import { AndroidVariantForm } from '../VariantForms/AndroidVariantForm';
 import { VariantSelectionForm } from '../VariantForms/VariantSelectionForm';
 
 interface State {

--- a/src/common/Header.tsx
+++ b/src/common/Header.tsx
@@ -8,10 +8,11 @@ import { PageHeader } from '@patternfly/react-core';
 export const Header = () => {
   return (
     <PageHeader
+      logoProps={{ href: 'https://aerogear.org' }}
       logo={
-        <a className="navbar-brand" href="https://aerogear.org">
-          <strong>AEROGEAR</strong> UNIFIEDPUSH SERVER
-        </a>
+        <>
+          <strong>AEROGEAR</strong>&nbsp; UNIFIEDPUSH SERVER
+        </>
       }
       showNavToggle={false}
       isNavOpen={true}

--- a/src/context/Context.ts
+++ b/src/context/Context.ts
@@ -1,8 +1,5 @@
 import React from 'react';
-import {
-  PushApplication,
-  VariantType,
-} from '@aerogear/unifiedpush-admin-client';
+import { PushApplication } from '@aerogear/unifiedpush-admin-client';
 import { AlertVariant } from '@patternfly/react-core';
 
 export interface Alert {


### PR DESCRIPTION
## Motivation
There were errors into the chrome console.
Code was somewhat cumbersome and redundant.

## What
Added new features to the validator:
* Ability to specify a custom error message
* Utility functions into the result to retrieve the status of a specified field

Cleaned some code:
* Used the FormField tag wherever possible to reduce code redundancy into the `Edit***NetworkOptions` objects
* Removed errors from the chrome console

Added validations
* Added validation to the `Edit**NetworkOptions` object
* Added custom error messages
