### PR TITLE
feat(applications): added the router component so that we can avoid using a dialog for the app details

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1762,6 +1762,11 @@
         }
       }
     },
+    "@types/history": {
+      "version": "4.7.7",
+      "resolved": "https://registry.npmjs.org/@types/history/-/history-4.7.7.tgz",
+      "integrity": "sha512-2xtoL22/3Mv6a70i4+4RB7VgbDDORoWwjcqeNysojZA0R7NK17RbY5Gof/2QiFfJgX+KkWghbwJ+d/2SB8Ndzg=="
+    },
     "@types/is-valid-path": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/@types/is-valid-path/-/is-valid-path-0.1.0.tgz",
@@ -1850,6 +1855,25 @@
       "dev": true,
       "requires": {
         "@types/react": "*"
+      }
+    },
+    "@types/react-router": {
+      "version": "5.1.8",
+      "resolved": "https://registry.npmjs.org/@types/react-router/-/react-router-5.1.8.tgz",
+      "integrity": "sha512-HzOyJb+wFmyEhyfp4D4NYrumi+LQgQL/68HvJO+q6XtuHSDvw6Aqov7sCAhjbNq3bUPgPqbdvjXC5HeB2oEAPg==",
+      "requires": {
+        "@types/history": "*",
+        "@types/react": "*"
+      }
+    },
+    "@types/react-router-dom": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@types/react-router-dom/-/react-router-dom-5.1.5.tgz",
+      "integrity": "sha512-ArBM4B1g3BWLGbaGvwBGO75GNFbLDUthrDojV2vHLih/Tq8M+tgvY1DSwkuNrPSwdp/GUL93WSEpTZs8nVyJLw==",
+      "requires": {
+        "@types/history": "*",
+        "@types/react": "*",
+        "@types/react-router": "*"
       }
     },
     "@types/react-syntax-highlighter": {
@@ -7155,6 +7179,19 @@
       "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-9.15.10.tgz",
       "integrity": "sha512-RoV7OkQm0T3os3Dd2VHLNMoaoDVx77Wygln3n9l5YV172XonWG6rgQD3XnF/BuFFZw9A0TJgmMSO8FEWQgvcXw=="
     },
+    "history": {
+      "version": "4.10.1",
+      "resolved": "https://registry.npmjs.org/history/-/history-4.10.1.tgz",
+      "integrity": "sha512-36nwAD620w12kuzPAsyINPWJqlNbij+hpK1k9XRloDtym8mxzGYl2c17LnV6IAGB2Dmg4tEa7G7DlawS0+qjew==",
+      "requires": {
+        "@babel/runtime": "^7.1.2",
+        "loose-envify": "^1.2.0",
+        "resolve-pathname": "^3.0.0",
+        "tiny-invariant": "^1.0.2",
+        "tiny-warning": "^1.0.0",
+        "value-equal": "^1.0.1"
+      }
+    },
     "hmac-drbg": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
@@ -7163,6 +7200,14 @@
         "hash.js": "^1.0.3",
         "minimalistic-assert": "^1.0.0",
         "minimalistic-crypto-utils": "^1.0.1"
+      }
+    },
+    "hoist-non-react-statics": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
+      "integrity": "sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==",
+      "requires": {
+        "react-is": "^16.7.0"
       }
     },
     "hosted-git-info": {
@@ -9464,6 +9509,15 @@
       "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
       "integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==",
       "dev": true
+    },
+    "mini-create-react-context": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/mini-create-react-context/-/mini-create-react-context-0.4.0.tgz",
+      "integrity": "sha512-b0TytUgFSbgFJGzJqXPKCFCBWigAjpjo+Fl7Vf7ZbKRDptszpppKxXH6DRXEABZ/gcEQczeb0iZ7JvL8e8jjCA==",
+      "requires": {
+        "@babel/runtime": "^7.5.5",
+        "tiny-warning": "^1.0.3"
+      }
     },
     "mini-css-extract-plugin": {
       "version": "0.9.0",
@@ -12355,6 +12409,52 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
     },
+    "react-router": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-5.2.0.tgz",
+      "integrity": "sha512-smz1DUuFHRKdcJC0jobGo8cVbhO3x50tCL4icacOlcwDOEQPq4TMqwx3sY1TP+DvtTgz4nm3thuo7A+BK2U0Dw==",
+      "requires": {
+        "@babel/runtime": "^7.1.2",
+        "history": "^4.9.0",
+        "hoist-non-react-statics": "^3.1.0",
+        "loose-envify": "^1.3.1",
+        "mini-create-react-context": "^0.4.0",
+        "path-to-regexp": "^1.7.0",
+        "prop-types": "^15.6.2",
+        "react-is": "^16.6.0",
+        "tiny-invariant": "^1.0.2",
+        "tiny-warning": "^1.0.0"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
+        },
+        "path-to-regexp": {
+          "version": "1.8.0",
+          "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.8.0.tgz",
+          "integrity": "sha512-n43JRhlUKUAlibEJhPeir1ncUID16QnEjNpwzNdO3Lm4ywrBpBZ5oLD0I6br9evr1Y9JTqwRtAh7JLoOzAQdVA==",
+          "requires": {
+            "isarray": "0.0.1"
+          }
+        }
+      }
+    },
+    "react-router-dom": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-5.2.0.tgz",
+      "integrity": "sha512-gxAmfylo2QUjcwxI63RhQ5G85Qqt4voZpUXSEqCwykV0baaOTQDR1f0PmY8AELqIyVc0NEZUj0Gov5lNGcXgsA==",
+      "requires": {
+        "@babel/runtime": "^7.1.2",
+        "history": "^4.9.0",
+        "loose-envify": "^1.3.1",
+        "prop-types": "^15.6.2",
+        "react-router": "5.2.0",
+        "tiny-invariant": "^1.0.2",
+        "tiny-warning": "^1.0.0"
+      }
+    },
     "react-scripts": {
       "version": "3.4.1",
       "resolved": "https://registry.npmjs.org/react-scripts/-/react-scripts-3.4.1.tgz",
@@ -12788,6 +12888,11 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-3.0.0.tgz",
       "integrity": "sha1-six699nWiBvItuZTM17rywoYh0g="
+    },
+    "resolve-pathname": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-pathname/-/resolve-pathname-3.0.0.tgz",
+      "integrity": "sha512-C7rARubxI8bXFNB/hqcp/4iUeIXJhJZvFPFPiSPRnhU5UPxzMFIl+2E6yY6c4k9giDJAhtV+enfA+G89N6Csng=="
     },
     "resolve-url": {
       "version": "0.2.1",
@@ -14445,6 +14550,16 @@
       "integrity": "sha512-NB6Dk1A9xgQPMoGqC5CVXn123gWyte215ONT5Pp5a0yt4nlEoO1ZWeCwpncaekPHXO60i47ihFnZPiRPjRMq4Q==",
       "optional": true
     },
+    "tiny-invariant": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.1.0.tgz",
+      "integrity": "sha512-ytxQvrb1cPc9WBEI/HSeYYoGD0kWnGEOR8RY6KomWLBVhqz0RgTwVO9dLrGz7dC+nN9llyI7OKAgRq8Vq4ZBSw=="
+    },
+    "tiny-warning": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/tiny-warning/-/tiny-warning-1.0.3.tgz",
+      "integrity": "sha512-lBN9zLN/oAf68o3zNXYrdCt1kP8WsiGW8Oo2ka41b2IM5JL/S1CTyX1rW0mb/zSuJun0ZUrDxx4sqvYS2FWzPA=="
+    },
     "tippy.js": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/tippy.js/-/tippy.js-5.1.2.tgz",
@@ -14954,6 +15069,11 @@
       "version": "13.1.1",
       "resolved": "https://registry.npmjs.org/validator/-/validator-13.1.1.tgz",
       "integrity": "sha512-8GfPiwzzRoWTg7OV1zva1KvrSemuMkv07MA9TTl91hfhe+wKrsrgVN4H2QSFd/U/FhiU3iWPYVgvbsOGwhyFWw=="
+    },
+    "value-equal": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/value-equal/-/value-equal-1.0.1.tgz",
+      "integrity": "sha512-NOJ6JZCAWr0zlxZt+xqCHNTEKOsrks2HQd4MqhP1qy4z1SkbEP467eNx6TgDKXMvUOb+OENfJCZwM+16n7fRfw=="
     },
     "vary": {
       "version": "1.1.2",

--- a/package.json
+++ b/package.json
@@ -6,11 +6,13 @@
     "@aerogear/unifiedpush-admin-client": "4.1.0",
     "@fortawesome/fontawesome-free": "^5.13.0",
     "@patternfly/react-core": "4.18.5",
+    "@types/react-router-dom": "^5.1.5",
     "@types/react-syntax-highlighter": "^11.0.4",
     "data-urls": "^2.0.0",
     "json-data-validator": "^2.1.0",
     "react": "^16.13.1",
     "react-dom": "^16.13.1",
+    "react-router-dom": "^5.2.0",
     "react-scripts": "3.4.1",
     "react-syntax-highlighter": "^12.2.1"
   },

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -9,6 +9,8 @@ import {
   Page,
   PageSection,
 } from '@patternfly/react-core';
+
+import { BrowserRouter as Router, Route } from 'react-router-dom';
 import { Welcome } from './landing';
 import { Header } from './common/Header';
 
@@ -17,7 +19,8 @@ import { UpsClientFactory } from './utils/UpsClientFactory';
 
 import './styles/App.scss';
 import { UpsError } from '@aerogear/unifiedpush-admin-client/dist/src/errors/UpsError';
-import { Variant } from '@aerogear/unifiedpush-admin-client';
+import { PushApplication, Variant } from '@aerogear/unifiedpush-admin-client';
+import { ApplicationDetail } from './application/ApplicationDetail/ApplicationDetail';
 
 export class App extends Component<{}, UpsAdminState> {
   constructor(props: {}) {
@@ -158,7 +161,21 @@ export class App extends Component<{}, UpsAdminState> {
           variant={'light'}
           style={{ padding: '0 0 0 0' }}
         >
-          <Welcome />
+          <Router>
+            <Route path="/" exact={true} component={Welcome} />
+            <Route
+              path="/app/:appId"
+              render={({ match }) => {
+                return (
+                  <ApplicationDetail
+                    app={this.state.applications.find(
+                      app => app.pushApplicationID === match.params.appId
+                    )}
+                  />
+                );
+              }}
+            />
+          </Router>
         </PageSection>
       </Page>
     </ApplicationListContext.Provider>

--- a/src/application/ApplicationDetail/ApplicationDetail.tsx
+++ b/src/application/ApplicationDetail/ApplicationDetail.tsx
@@ -1,14 +1,22 @@
 import React, { Component } from 'react';
 import { PushApplication } from '@aerogear/unifiedpush-admin-client';
 import { NoVariantsPanel } from './panels/NoVariantsPanel';
-import { Modal, Tabs, Tab } from '@patternfly/react-core';
+import {
+  Tabs,
+  Tab,
+  TextVariants,
+  Text,
+  Breadcrumb,
+  BreadcrumbItem,
+  GridItem,
+  Grid,
+} from '@patternfly/react-core';
 import { VariantsPanel } from './panels/VariantsPanel';
 import { SenderAPI } from './SenderAPI';
+import { ApplicationStats } from '../../landing/components/ApplicationStats';
 
 interface Props {
   app?: PushApplication;
-  show: boolean;
-  onClose: (app: PushApplication) => void;
 }
 
 interface State {
@@ -29,31 +37,66 @@ export class ApplicationDetail extends Component<Props, State> {
     };
 
     return (
-      <Modal
-        aria-label={'app-details-modal'}
-        title={this.props.app?.name || ''}
-        isOpen={this.props.show}
-        onClose={() =>
-          this.props.onClose && this.props.onClose(this.props.app!)
-        }
-      >
-        <Tabs
-          activeKey={this.state.activeTab}
-          isBox={true}
-          onSelect={(evt, key) => onTabSelect(key as number)}
+      <Grid style={{ height: '100%' }}>
+        <GridItem sm={8} md={9}>
+          <div
+            style={{
+              paddingLeft: 25,
+              paddingRight: 25,
+            }}
+          >
+            <Breadcrumb>
+              <BreadcrumbItem to="/">Applications</BreadcrumbItem>
+              <BreadcrumbItem to="#" isActive>{`${
+                this.props.app!.name
+              }: Variants`}</BreadcrumbItem>
+            </Breadcrumb>
+            <Text
+              component={TextVariants.h1}
+              style={{
+                paddingTop: 40,
+                paddingBottom: 20,
+              }}
+            >
+              {this.props.app!.name}
+            </Text>
+            <Tabs
+              activeKey={this.state.activeTab}
+              isBox={true}
+              onSelect={(evt, key) => onTabSelect(key as number)}
+            >
+              <Tab eventKey={0} title="Variants">
+                <NoVariantsPanel app={this.props.app} />
+                {this.props.app?.variants &&
+                  this.props.app.variants.length > 0 && (
+                    <Text
+                      style={{ paddingTop: 20, paddingBottom: 10 }}
+                    >{`You have ${this.props.app.variants.length} Variant${
+                      this.props.app.variants.length === 1 ? '' : 's'
+                    }`}</Text>
+                  )}
+                <VariantsPanel app={this.props.app} variantType="android" />
+                <VariantsPanel app={this.props.app} variantType="ios" />
+                <VariantsPanel app={this.props.app} variantType="ios_token" />
+                <VariantsPanel app={this.props.app} variantType="web_push" />
+              </Tab>
+              <Tab eventKey={1} title="Sender API">
+                <SenderAPI app={this.props.app!} />
+              </Tab>
+            </Tabs>
+          </div>
+        </GridItem>
+        <GridItem
+          sm={4}
+          md={3}
+          style={{
+            backgroundColor: '#F9F9F9',
+            borderLeft: 'solid 1px #C5C5C5',
+          }}
         >
-          <Tab eventKey={0} title="Variants">
-            <NoVariantsPanel app={this.props.app} />
-            <VariantsPanel app={this.props.app} variantType="android" />
-            <VariantsPanel app={this.props.app} variantType="ios" />
-            <VariantsPanel app={this.props.app} variantType="ios_token" />
-            <VariantsPanel app={this.props.app} variantType="web_push" />
-          </Tab>
-          <Tab eventKey={1} title="Sender API">
-            <SenderAPI app={this.props.app!} />
-          </Tab>
-        </Tabs>
-      </Modal>
+          <ApplicationStats app={this.props.app!} />
+        </GridItem>
+      </Grid>
     );
   };
 }

--- a/src/application/ApplicationList/ApplicationList.tsx
+++ b/src/application/ApplicationList/ApplicationList.tsx
@@ -80,11 +80,6 @@ export class ApplicationList extends Component<Props, State> {
         {({ applications, refresh, total }: ContextInterface): ReactNode => {
           return (
             <>
-              <ApplicationDetail
-                app={this.state.selectedApp}
-                show={this.state.showAppDetailPage}
-                onClose={(app: PushApplication) => closeAllDialogs()}
-              />
               <UpdateApplicationPage
                 open={this.state.updateApplicationPage}
                 app={this.state.selectedApp}

--- a/src/application/ApplicationList/ApplicationListItem.tsx
+++ b/src/application/ApplicationList/ApplicationListItem.tsx
@@ -20,6 +20,7 @@ import {
   TrashIcon,
   UserIcon,
 } from '@patternfly/react-icons';
+import { Link } from 'react-router-dom';
 
 interface Props {
   app: PushApplication;
@@ -30,82 +31,87 @@ interface Props {
 
 export class ApplicationListItem extends Component<Props> {
   render = () => (
-    <DataListItem
-      aria-labelledby={'item'}
-      key={this.props.app.pushApplicationID}
-      className="appList"
-      onClick={() => this.props.onClick && this.props.onClick(this.props.app)}
-    >
-      <DataListItemRow>
-        <DataListItemCells
-          dataListCells={[
-            <DataListCell isIcon key="icon" width={1}>
-              <div className={'app-icon'}>{this.props.app.name.charAt(0)}</div>
-            </DataListCell>,
-            <DataListCell key="primary content" width={5}>
-              <Text component={TextVariants.h2}>{this.props.app.name}</Text>
-              <List variant={ListVariant.inline} className={'subtitle'}>
-                <ListItem>
-                  <Label
-                    text={`created by ${this.props.app.developer}`}
-                    icon={<UserIcon />}
-                  />
-                </ListItem>
-                <ListItem>
-                  <Label
-                    text={`${
-                      this.props.app.variants
-                        ? this.props.app.variants.length
-                        : 0
-                    } variants`}
-                    icon={'fa fa-code-branch'}
-                  />
-                </ListItem>
-                <ListItem>
-                  <Label text={'0 messages sent'} icon={<MessagesIcon />} />
-                </ListItem>
-                <ListItem>
-                  <Label
-                    text={'0 devices registered'}
-                    icon={<MobileAltIcon />}
-                  />
-                </ListItem>
-              </List>
-            </DataListCell>,
-            <DataListCell key="buttons">
-              <List className="buttonGroup" variant={ListVariant.inline}>
-                <ListItem>
-                  <Button
-                    className="editBtn"
-                    variant="secondary"
-                    icon={<EditIcon />}
-                    onClick={evt => {
-                      evt.stopPropagation();
-                      return (
-                        this.props.onEdit && this.props.onEdit(this.props.app)
-                      );
-                    }}
-                  />
-                </ListItem>
-                <ListItem>
-                  <Button
-                    className="deleteBtn"
-                    variant="danger"
-                    icon={<TrashIcon />}
-                    onClick={evt => {
-                      evt.stopPropagation();
-                      return (
-                        this.props.onDelete &&
-                        this.props.onDelete(this.props.app)
-                      );
-                    }}
-                  />
-                </ListItem>
-              </List>
-            </DataListCell>,
-          ]}
-        />
-      </DataListItemRow>
-    </DataListItem>
+    <Link to={`/app/${this.props.app.pushApplicationID}`}>
+      <DataListItem
+        aria-labelledby={'item'}
+        key={this.props.app.pushApplicationID}
+        className="appList"
+      >
+        <DataListItemRow>
+          <DataListItemCells
+            dataListCells={[
+              <DataListCell isIcon key="icon" width={1}>
+                <div className={'app-icon'}>
+                  {this.props.app.name.charAt(0)}
+                </div>
+              </DataListCell>,
+              <DataListCell key="primary content" width={5}>
+                <Text component={TextVariants.h2}>{this.props.app.name}</Text>
+                <List variant={ListVariant.inline} className={'subtitle'}>
+                  <ListItem>
+                    <Label
+                      text={`created by ${this.props.app.developer}`}
+                      icon={<UserIcon />}
+                    />
+                  </ListItem>
+                  <ListItem>
+                    <Label
+                      text={`${
+                        this.props.app.variants
+                          ? this.props.app.variants.length
+                          : 0
+                      } variants`}
+                      icon={'fa fa-code-branch'}
+                    />
+                  </ListItem>
+                  <ListItem>
+                    <Label text={'0 messages sent'} icon={<MessagesIcon />} />
+                  </ListItem>
+                  <ListItem>
+                    <Label
+                      text={'0 devices registered'}
+                      icon={<MobileAltIcon />}
+                    />
+                  </ListItem>
+                </List>
+              </DataListCell>,
+              <DataListCell key="buttons">
+                <List className="buttonGroup" variant={ListVariant.inline}>
+                  <ListItem>
+                    <Button
+                      className="editBtn"
+                      variant="secondary"
+                      icon={<EditIcon />}
+                      onClick={evt => {
+                        evt.preventDefault();
+                        evt.stopPropagation();
+                        return (
+                          this.props.onEdit && this.props.onEdit(this.props.app)
+                        );
+                      }}
+                    />
+                  </ListItem>
+                  <ListItem>
+                    <Button
+                      className="deleteBtn"
+                      variant="danger"
+                      icon={<TrashIcon />}
+                      onClick={evt => {
+                        evt.preventDefault();
+                        evt.stopPropagation();
+                        return (
+                          this.props.onDelete &&
+                          this.props.onDelete(this.props.app)
+                        );
+                      }}
+                    />
+                  </ListItem>
+                </List>
+              </DataListCell>,
+            ]}
+          />
+        </DataListItemRow>
+      </DataListItem>
+    </Link>
   );
 }

--- a/src/landing/components/ApplicationStats.tsx
+++ b/src/landing/components/ApplicationStats.tsx
@@ -1,0 +1,61 @@
+import { PushApplication } from '@aerogear/unifiedpush-admin-client';
+import React, { Component } from 'react';
+import {
+  Divider,
+  Grid,
+  GridItem,
+  Text,
+  TextVariants,
+} from '@patternfly/react-core';
+
+interface Props {
+  app: PushApplication;
+}
+
+export class ApplicationStats extends Component<Props> {
+  render() {
+    return (
+      <div className={'apps-dashboard'}>
+        <Text
+          component={TextVariants.h6}
+          //size="md"
+          style={{
+            paddingTop: 51,
+            paddingLeft: 20,
+            paddingBottom: 21,
+            fontSize: 15,
+          }}
+        >
+          App Statistics
+        </Text>
+        <Divider />
+        <Grid style={{ paddingLeft: 20, paddingTop: 20 }}>
+          <GridItem sm={4}>
+            <div>
+              <Text className={'ups-count'}>
+                {this.props.app.variants!.length}
+              </Text>
+              <Text className={'ups-count-label'}>Variant</Text>
+            </div>
+          </GridItem>
+          <GridItem sm={4}>
+            <div>
+              <Text className={'ups-count'}>
+                {this.props.app!.metadata?.activity || 0}
+              </Text>
+              <Text className={'ups-count-label'}>Messages</Text>
+            </div>
+          </GridItem>
+          <GridItem sm={4}>
+            <div>
+              <Text className={'ups-count'}>
+                {this.props.app!.metadata?.deviceCount || 0}
+              </Text>
+              <Text className={'ups-count-label'}>Devices</Text>
+            </div>
+          </GridItem>
+        </Grid>
+      </div>
+    );
+  }
+}


### PR DESCRIPTION
## Motivation
We were using a modal dialog to show the app details. However since modals are currently centred in PATTERNFLY 4, it was awful for the window to be continuously resized and re-centred every time an item was expanded.

https://issues.jboss.org/browse/AEROGEAR-10305

## What
Added the router so that a different route can be used to show a different page for the app details.
Added the Breadcrumb

