### PR TITLE
fix(application): fixed null error when refreshing on page detail

### DIFF
--- a/src/application/ApplicationDetail/ApplicationDetail.tsx
+++ b/src/application/ApplicationDetail/ApplicationDetail.tsx
@@ -36,6 +36,10 @@ export class ApplicationDetail extends Component<Props, State> {
       this.setState({ activeTab: tabKey });
     };
 
+    if (!this.props.app) {
+      return null;
+    }
+
     return (
       <Grid style={{ height: '100%' }}>
         <GridItem sm={8} md={9}>


### PR DESCRIPTION
## Motivation
When refreshing, the properties are null until the call to the server ends.

## What
With this fix, if the properties are null, nothing is rendered, so that the page gets rendered as soon as the call ends
