### PR TITLE
Added a new component that allows to blur secret text

### DIFF
--- a/src/application/ApplicationDetail/SenderAPI.tsx
+++ b/src/application/ApplicationDetail/SenderAPI.tsx
@@ -22,6 +22,7 @@ import { snippet as java_snippet } from './snippets/sender/java';
 import { snippet as node_snippet } from './snippets/sender/node';
 import { snippet as curl_snippet } from './snippets/sender/curl';
 import { links } from '../../links';
+import { Secret } from '../../common/Secret';
 
 interface State {
   refreshSecret: boolean;
@@ -80,7 +81,7 @@ export class SenderAPI extends Component<Props, State> {
               Master Secret:
             </TextListItem>
             <TextListItem component={TextListItemVariants.dd}>
-              {this.props.app.masterSecret}
+              <Secret text={this.props.app.masterSecret} />
             </TextListItem>
 
             <TextListItem component={TextListItemVariants.dd}>

--- a/src/application/ApplicationDetail/panels/VariantDetails.tsx
+++ b/src/application/ApplicationDetail/panels/VariantDetails.tsx
@@ -24,6 +24,7 @@ import { IOSCertVariantDetails } from './ios_cert/iOSCertVariantDetails';
 import { IOSCertCodeSnippets } from './ios_cert/iOSCertCodeSnippets';
 import { WebPushVariantDetails } from './web_push/WebPushVariantDetails';
 import { WebPushCodeSnippets } from './web_push/WebPushCodeSnippets';
+import { Secret } from '../../../common/Secret';
 
 interface Props {
   app: PushApplication;
@@ -138,7 +139,7 @@ export class VariantDetails extends Component<Props, State> {
               Variant Secret:
             </TextListItem>
             <TextListItem component={TextListItemVariants.dd}>
-              {this.props.variant.secret}
+              <Secret text={this.props.variant.secret} />
             </TextListItem>
 
             <TextListItem component={TextListItemVariants.dd}>

--- a/src/common/Secret.tsx
+++ b/src/common/Secret.tsx
@@ -1,0 +1,66 @@
+import React, { Component } from 'react';
+import { Text, TextVariants, Tooltip } from '@patternfly/react-core';
+import { EyeIcon, EyeSlashIcon } from '@patternfly/react-icons';
+
+interface State {
+  visible: boolean;
+}
+
+interface Props {
+  text: string;
+}
+
+const hidden = {
+  color: 'transparent',
+  textShadow: '0 0 5px rgba(0,0,0,0.5)',
+};
+
+const visible = {
+  color: 'black',
+};
+
+export class Secret extends Component<Props, State> {
+  constructor(props: Props) {
+    super(props);
+    this.state = {
+      visible: false,
+    };
+  }
+
+  render = () => {
+    const icon = () => {
+      if (this.state.visible) {
+        return (
+          <EyeSlashIcon
+            style={{
+              color: 'black',
+              verticalAlign: 'middle',
+              paddingBottom: 3,
+            }}
+            onClick={() => this.setState({ visible: false })}
+          />
+        );
+      } else {
+        return (
+          <EyeIcon
+            style={{
+              color: 'black',
+              verticalAlign: 'middle',
+              paddingBottom: 3,
+            }}
+            onClick={() => this.setState({ visible: true })}
+          />
+        );
+      }
+    };
+
+    return (
+      <Text
+        style={this.state.visible ? visible : hidden}
+        component={TextVariants.small}
+      >
+        {this.props.text}&nbsp;{icon()}
+      </Text>
+    );
+  };
+}


### PR DESCRIPTION
## Motivation
We show in the webpage both master secrets and variant secrets

## What
Added a new component called `Secret` that automatically blur the text and shows an icon that allows to unblur it.

## Example Usage
```typescrypt
<Secret text='secret text'/>
```

## Screenshots
### Blur
<img width="1326" alt="Screenshot 2020-08-19 at 13 52 34" src="https://user-images.githubusercontent.com/1125019/90631581-4b1ac600-e223-11ea-8a08-b726734f5a7e.png">

### Unblur
<img width="1337" alt="Screenshot 2020-08-19 at 13 52 45" src="https://user-images.githubusercontent.com/1125019/90631646-638ae080-e223-11ea-9a2e-f13a3fe9ea3b.png">
