### PR TITLE
feat: Rename & Delete Variant Buttons added

### DIFF
--- a/src/application/ApplicationDetail/ApplicationDetail.tsx
+++ b/src/application/ApplicationDetail/ApplicationDetail.tsx
@@ -43,6 +43,9 @@ export class ApplicationDetail extends Component<Props, State> {
     const onTabSelect = (tabKey: number) => {
       this.setState({ activeTab: tabKey });
     };
+    if (!this.props.app) {
+      return null;
+    }
 
     if (!this.props.app) {
       return null;

--- a/src/application/ApplicationDetail/panels/VariantItem.tsx
+++ b/src/application/ApplicationDetail/panels/VariantItem.tsx
@@ -13,8 +13,16 @@ import {
   DataListToggle,
   Text,
   TextVariants,
+  Button,
+  ListVariant,
+  List,
+  ListItem,
 } from '@patternfly/react-core';
 import { VariantDetails } from './VariantDetails';
+import { EditIcon, TrashIcon } from '@patternfly/react-icons';
+import { DeleteVariantPage } from '../../crud/DeleteVariantPage';
+import { RenameVariantPage } from '../../crud/RenameVariantPage';
+import { ApplicationListContext, ContextInterface } from '../../../context/Context';
 
 interface Props {
   app: PushApplication;
@@ -23,6 +31,9 @@ interface Props {
 
 interface State {
   expanded: boolean;
+  deleteVariantPage: boolean;
+  editVariantPage: boolean;
+  selectedVariant?: Variant;
 }
 
 export class VariantItem extends Component<Props, State> {
@@ -30,6 +41,8 @@ export class VariantItem extends Component<Props, State> {
     super(props);
     this.state = {
       expanded: false,
+      deleteVariantPage: false,
+      editVariantPage: false,
     };
   }
 
@@ -37,43 +50,82 @@ export class VariantItem extends Component<Props, State> {
     const toggle = () => {
       this.setState({ expanded: !this.state.expanded });
     };
+    const context = this.context as ContextInterface;
     return (
-      <DataListItem aria-labelledby="ex-item1" isExpanded={this.state.expanded}>
-        <DataListItemRow>
-          <DataListToggle
-            onClick={() => toggle()}
-            isExpanded={this.state.expanded}
-            id="ex-toggle1"
-            aria-controls="ex-expand1"
-          />
-          <DataListItemCells
-            dataListCells={[
-              <DataListCell key="primary content">
-                <div id="ex-item1">
-                  {this.props.variant.name}
-                  <Text
-                    style={{ paddingLeft: 20, color: '#999' }}
-                    component={TextVariants.small}
-                  >
-                    <i style={{ paddingRight: 5 }} className="fas fa-ban" />
-                    No installation yet
-                  </Text>
-                </div>
-              </DataListCell>,
-            ]}
-          />
-        </DataListItemRow>
-        <DataListContent
-          aria-label="Primary Content Details"
-          id="ex-expand1"
-          isHidden={!this.state.expanded}
+      <>
+        <DataListItem
+          className="varList"
+          aria-labelledby="ex-item1"
+          isExpanded={this.state.expanded}
         >
-          <VariantDetails
-            variant={this.props.variant as AndroidVariant}
-            app={this.props.app}
-          />
-        </DataListContent>
-      </DataListItem>
+          <DataListItemRow>
+            <DataListToggle
+              onClick={() => toggle()}
+              isExpanded={this.state.expanded}
+              id="ex-toggle1"
+              aria-controls="ex-expand1"
+            />
+            <DataListItemCells
+              dataListCells={[
+                <DataListCell key="primary content">
+                  <div id="ex-item1">
+                    {this.props.variant.name}
+                    <Text
+                      style={{ paddingLeft: 20, color: '#999' }}
+                      component={TextVariants.small}
+                    >
+                      <i style={{ paddingRight: 5 }} className="fas fa-ban" />
+                      No installation yet
+                    </Text>
+                  </div>
+                </DataListCell>,
+                <DataListCell key="buttons">
+                  <List className="varBtnGroup" variant={ListVariant.inline}>
+                    <ListItem>
+                      <Button
+                        className="editBtn"
+                        variant="secondary"
+                        icon={<EditIcon />}
+                        onClick={async () => { await context.selectVariant(this.props.variant); this.setState({ editVariantPage: true }) }}
+                      />
+                    </ListItem>
+                    <ListItem>
+                      <Button
+                        className="deleteBtn"
+                        variant="danger"
+                        icon={<TrashIcon />}
+                        onClick={async () => { await context.selectVariant(this.props.variant); this.setState({ deleteVariantPage: true }) }
+                        }
+                      />
+                    </ListItem>
+                  </List>
+                </DataListCell>,
+              ]}
+            />
+          </DataListItemRow>
+          <DataListContent
+            aria-label="Primary Content Details"
+            id="ex-expand1"
+            isHidden={!this.state.expanded}
+          >
+            <VariantDetails
+              variant={this.props.variant as AndroidVariant}
+              app={this.props.app}
+            />
+          </DataListContent>
+        </DataListItem>
+        <DeleteVariantPage
+          open={this.state.deleteVariantPage}
+          close={() => this.setState({ deleteVariantPage: false })}
+          app={this.props.app}
+        />
+        <RenameVariantPage
+          open={this.state.editVariantPage}
+          close={() => this.setState({ editVariantPage: false })}
+          app={this.props.app}
+        />
+      </>
     );
   };
 }
+VariantItem.contextType = ApplicationListContext;

--- a/src/application/ApplicationDetail/panels/VariantItem.tsx
+++ b/src/application/ApplicationDetail/panels/VariantItem.tsx
@@ -22,7 +22,10 @@ import { VariantDetails } from './VariantDetails';
 import { EditIcon, TrashIcon } from '@patternfly/react-icons';
 import { DeleteVariantPage } from '../../crud/DeleteVariantPage';
 import { RenameVariantPage } from '../../crud/RenameVariantPage';
-import { ApplicationListContext, ContextInterface } from '../../../context/Context';
+import {
+  ApplicationListContext,
+  ContextInterface,
+} from '../../../context/Context';
 
 interface Props {
   app: PushApplication;
@@ -86,7 +89,10 @@ export class VariantItem extends Component<Props, State> {
                         className="editBtn"
                         variant="secondary"
                         icon={<EditIcon />}
-                        onClick={async () => { await context.selectVariant(this.props.variant); this.setState({ editVariantPage: true }) }}
+                        onClick={async () => {
+                          await context.selectVariant(this.props.variant);
+                          this.setState({ editVariantPage: true });
+                        }}
                       />
                     </ListItem>
                     <ListItem>
@@ -94,8 +100,10 @@ export class VariantItem extends Component<Props, State> {
                         className="deleteBtn"
                         variant="danger"
                         icon={<TrashIcon />}
-                        onClick={async () => { await context.selectVariant(this.props.variant); this.setState({ deleteVariantPage: true }) }
-                        }
+                        onClick={async () => {
+                          await context.selectVariant(this.props.variant);
+                          this.setState({ deleteVariantPage: true });
+                        }}
                       />
                     </ListItem>
                   </List>

--- a/src/application/crud/DeleteVariantPage.tsx
+++ b/src/application/crud/DeleteVariantPage.tsx
@@ -1,0 +1,110 @@
+import React, { Component } from 'react';
+import { UpsClientFactory } from '../../utils/UpsClientFactory';
+import {
+  Form,
+  TextInput,
+  FormGroup,
+  Button,
+  Modal,
+} from '@patternfly/react-core';
+import { PushApplication, Variant, VariantType } from '@aerogear/unifiedpush-admin-client';
+import { ApplicationListContext, ContextInterface } from '../../context/Context';
+
+interface State {
+  varName: string;
+}
+
+interface Props {
+  app: PushApplication;
+  variant?: Variant;
+  open: boolean;
+  close: () => void;
+}
+
+export class DeleteVariantPage extends Component<Props, State> {
+  constructor(props: Props) {
+    super(props);
+    this.state = {
+      varName: '',
+    };
+  }
+
+  private readonly deleteVariant = async (
+    app: PushApplication,
+    variant: Variant,
+    providedName: string
+  ) => {
+    try {
+      if (providedName === variant.name) {
+        await UpsClientFactory.getUpsClient()
+          .variants.delete(app.pushApplicationID)
+          .withName(providedName)
+          .execute();
+        // this.props.app.variants = this.props.app!.variants!.filter(filteredVar => filteredVar.variantID !== variant.variantID);
+        this.props.close();
+        (this.context as ContextInterface).refresh();
+      }
+    } catch (err) {
+      console.log(err);
+    }
+  };
+
+  render(): React.ReactNode {
+
+    const context = this.context as ContextInterface;
+
+    return this.props.app ? (
+      <Modal
+        title="Delete Variant"
+        isOpen={this.props.open}
+        onClose={this.props.close}
+        variant={'small'}
+      >
+        <Form className="dialog-form">
+          <FormGroup
+            fieldId="simple-form-title"
+            helperText={
+              <>
+                Are you sure you want to delete "<b>{context.selectedVariant?.name}</b>"?
+              </>
+            }
+          ></FormGroup>
+          <FormGroup
+            helperText="Please type in the name of the Variant to confirm."
+            fieldId="simple-form-input"
+          >
+            <TextInput
+              className="formInput"
+              onChange={value => this.setState({ varName: value })}
+              isRequired
+            />
+          </FormGroup>
+          <div className="formButtons">
+            <Button
+              className="dialogBtn"
+              variant="danger"
+              isDisabled={this.state.varName !== context.selectedVariant?.name}
+              onClick={() =>
+                this.deleteVariant(
+                  this.props.app!,
+                  context.selectedVariant!,
+                  this.state.varName,
+                )
+              }
+
+            >
+              Delete
+            </Button>
+            <Button variant="secondary" onClick={() => this.props.close()}>
+              Cancel
+            </Button>
+          </div>
+        </Form>
+      </Modal>
+    ) : (
+        <></>
+      );
+
+  };
+}
+DeleteVariantPage.contextType = ApplicationListContext;

--- a/src/application/crud/DeleteVariantPage.tsx
+++ b/src/application/crud/DeleteVariantPage.tsx
@@ -7,8 +7,15 @@ import {
   Button,
   Modal,
 } from '@patternfly/react-core';
-import { PushApplication, Variant, VariantType } from '@aerogear/unifiedpush-admin-client';
-import { ApplicationListContext, ContextInterface } from '../../context/Context';
+import {
+  PushApplication,
+  Variant,
+  VariantType,
+} from '@aerogear/unifiedpush-admin-client';
+import {
+  ApplicationListContext,
+  ContextInterface,
+} from '../../context/Context';
 
 interface State {
   varName: string;
@@ -50,7 +57,6 @@ export class DeleteVariantPage extends Component<Props, State> {
   };
 
   render(): React.ReactNode {
-
     const context = this.context as ContextInterface;
 
     return this.props.app ? (
@@ -65,7 +71,8 @@ export class DeleteVariantPage extends Component<Props, State> {
             fieldId="simple-form-title"
             helperText={
               <>
-                Are you sure you want to delete "<b>{context.selectedVariant?.name}</b>"?
+                Are you sure you want to delete "
+                <b>{context.selectedVariant?.name}</b>"?
               </>
             }
           ></FormGroup>
@@ -88,10 +95,9 @@ export class DeleteVariantPage extends Component<Props, State> {
                 this.deleteVariant(
                   this.props.app!,
                   context.selectedVariant!,
-                  this.state.varName,
+                  this.state.varName
                 )
               }
-
             >
               Delete
             </Button>
@@ -102,9 +108,8 @@ export class DeleteVariantPage extends Component<Props, State> {
         </Form>
       </Modal>
     ) : (
-        <></>
-      );
-
-  };
+      <></>
+    );
+  }
 }
 DeleteVariantPage.contextType = ApplicationListContext;

--- a/src/application/crud/RenameVariantPage.tsx
+++ b/src/application/crud/RenameVariantPage.tsx
@@ -8,7 +8,10 @@ import {
   Modal,
 } from '@patternfly/react-core';
 import { PushApplication, Variant } from '@aerogear/unifiedpush-admin-client';
-import { ApplicationListContext, ContextInterface } from '../../context/Context';
+import {
+  ApplicationListContext,
+  ContextInterface,
+} from '../../context/Context';
 
 interface State {
   varName: string;
@@ -47,7 +50,6 @@ export class RenameVariantPage extends Component<Props, State> {
   };
 
   render(): React.ReactNode {
-
     const context = this.context as ContextInterface;
 
     return this.props.app ? (
@@ -81,7 +83,6 @@ export class RenameVariantPage extends Component<Props, State> {
             <Button
               className="dialogBtn"
               variant="primary"
-
               onClick={() =>
                 this.editVariant(
                   this.props.app!,
@@ -99,8 +100,8 @@ export class RenameVariantPage extends Component<Props, State> {
         </Form>
       </Modal>
     ) : (
-        <></>
-      );
+      <></>
+    );
   }
 }
 RenameVariantPage.contextType = ApplicationListContext;

--- a/src/application/crud/RenameVariantPage.tsx
+++ b/src/application/crud/RenameVariantPage.tsx
@@ -1,0 +1,106 @@
+import React, { Component } from 'react';
+import { UpsClientFactory } from '../../utils/UpsClientFactory';
+import {
+  Form,
+  TextInput,
+  FormGroup,
+  Button,
+  Modal,
+} from '@patternfly/react-core';
+import { PushApplication, Variant } from '@aerogear/unifiedpush-admin-client';
+import { ApplicationListContext, ContextInterface } from '../../context/Context';
+
+interface State {
+  varName: string;
+}
+
+interface Props {
+  app?: PushApplication;
+  variant?: Variant;
+  open: boolean;
+  close: () => void;
+}
+
+export class RenameVariantPage extends Component<Props, State> {
+  constructor(props: Props) {
+    super(props);
+    this.state = {
+      varName: '',
+    };
+  }
+
+  private readonly editVariant = async (
+    app: PushApplication,
+    variant: Variant,
+    providedName: string
+  ) => {
+    try {
+      await UpsClientFactory.getUpsClient()
+        .variants[variant.type].update(app.pushApplicationID, variant.variantID)
+        .withName(providedName)
+        .execute();
+      this.props.close();
+      (this.context as ContextInterface).refresh();
+    } catch (err) {
+      console.log(err);
+    }
+  };
+
+  render(): React.ReactNode {
+
+    const context = this.context as ContextInterface;
+
+    return this.props.app ? (
+      <Modal
+        title="Update Variant Name"
+        isOpen={this.props.open}
+        onClose={this.props.close}
+        variant={'small'}
+      >
+        <Form className="dialog-form">
+          <FormGroup
+            fieldId="simple-form-title"
+            helperText={
+              <>
+                You are updating "<b>{context.selectedVariant?.name}</b>"?
+              </>
+            }
+          ></FormGroup>
+          <FormGroup
+            helperText="Please type in the name of the Variant to confirm."
+            fieldId="simple-form-input"
+          >
+            <TextInput
+              className="formInput"
+              defaultValue={this.props.app?.variants![0].name}
+              onChange={value => this.setState({ varName: value })}
+              isRequired
+            />
+          </FormGroup>
+          <div className="formButtons">
+            <Button
+              className="dialogBtn"
+              variant="primary"
+
+              onClick={() =>
+                this.editVariant(
+                  this.props.app!,
+                  context.selectedVariant!,
+                  this.state.varName
+                )
+              }
+            >
+              Save
+            </Button>
+            <Button variant="secondary" onClick={() => this.props.close()}>
+              Cancel
+            </Button>
+          </div>
+        </Form>
+      </Modal>
+    ) : (
+        <></>
+      );
+  }
+}
+RenameVariantPage.contextType = ApplicationListContext;

--- a/src/styles/App.scss
+++ b/src/styles/App.scss
@@ -125,15 +125,25 @@ emptyState {
   margin-right: 10px;
 }
 
-.ups-title-h3 {
-  margin-top: 20px;
-  margin-bottom: 10px;
+.addVariantBtn {
+  display: flex;
+  align-items: center;
 }
 
-.code {
-  padding: 2px 4px;
-  color: #c7254e;
-  background-color: #f9f2f4;
-  border-radius: 1px;
-  box-sizing: border-box;
+//styling for buttons on the variant list
+
+.varBtnGroup {
+  align-items: center;
+  height: 100%;
+  display: flex;
+  float: right;
+  opacity: 0;
+  transition: opacity 0.4s ease-in-out;
 }
+
+.varList:hover {
+  cursor: pointer;
+  .varBtnGroup {
+    opacity: 1;
+  }
+} 


### PR DESCRIPTION
These buttons are attached to the VariantItem Components and will appear when a user mouses over the
 component, this behavior is the same as how the Rename and Delete
 buttons work for the Application.

## Motivation
https://issues.redhat.com/browse/AEROGEAR-10213

## What
This emulates how the "edit" and "delete" buttons functioned on the old Admin UI,

The old Admin UI Edit dialog
![Old-Rename](https://user-images.githubusercontent.com/35809052/90887635-a4fac780-e3ac-11ea-9e44-2e8e3a8496df.png)

The new Rename Variant dialog
![New-Rename-Variant](https://user-images.githubusercontent.com/35809052/90887664-b348e380-e3ac-11ea-90e2-b844f281da6e.png)

The old Delete Variant dialog
![Old-Delete](https://user-images.githubusercontent.com/35809052/90887686-bcd24b80-e3ac-11ea-81a4-9864f3a02931.png)

The new Delete Variant dialog
![New-Delete-Variant](https://user-images.githubusercontent.com/35809052/90887748-d2477580-e3ac-11ea-8586-db0c34ec117d.png)


## Checklist:

- [x] Code has been tested locally by PR requester
- [ ] Changes have been successfully verified by another team member 


 

