### PR TITLE
fix: 🐛 Various fixes for the wizard pages

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3348,6 +3348,15 @@
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.1.0.tgz",
       "integrity": "sha512-1Yj8h9Q+QDF5FzhMs/c9+6UntbD5MkRfRwac8DoEm9ZfUBZ7tZ55YcGVAzEe4bXsdQHEk+s9S5wsOKVdZrw0tQ=="
     },
+    "bindings": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+      "optional": true,
+      "requires": {
+        "file-uri-to-path": "1.0.0"
+      }
+    },
     "block-stream": {
       "version": "0.0.9",
       "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.9.tgz",
@@ -6452,6 +6461,12 @@
         "tslib": "^1.9.0"
       }
     },
+    "file-uri-to-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+      "optional": true
+    },
     "filesize": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/filesize/-/filesize-6.0.1.tgz",
@@ -8499,6 +8514,7 @@
           "integrity": "sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==",
           "optional": true,
           "requires": {
+            "bindings": "^1.5.0",
             "nan": "^2.12.1"
           }
         }
@@ -16917,6 +16933,7 @@
           "integrity": "sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==",
           "optional": true,
           "requires": {
+            "bindings": "^1.5.0",
             "nan": "^2.12.1"
           }
         },
@@ -17229,6 +17246,7 @@
           "integrity": "sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==",
           "optional": true,
           "requires": {
+            "bindings": "^1.5.0",
             "nan": "^2.12.1"
           }
         },

--- a/package-lock.json
+++ b/package-lock.json
@@ -8940,9 +8940,9 @@
       "dev": true
     },
     "json-data-validator": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/json-data-validator/-/json-data-validator-2.2.0.tgz",
-      "integrity": "sha512-TjKpqMXOc2Kpy5wcodCQKVv6MPW7zHuKqDJyJrITJtddhXS+siWZpekIzUyxORNnSOLaeMlm+0r363fh6GurAw==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/json-data-validator/-/json-data-validator-2.3.0.tgz",
+      "integrity": "sha512-i1tLuvFzN3VuBAM9rP9UKc0kXuvjnSogVUlmEyBs03S/kSjabSOP5lCHsxH5N4B7UXWWqdpHQwibe/1gNw5oVw==",
       "requires": {
         "@types/is-valid-path": "^0.1.0",
         "@types/lodash": "^4.14.146",

--- a/package.json
+++ b/package.json
@@ -5,8 +5,8 @@
   "dependencies": {
     "@aerogear/unifiedpush-admin-client": "4.3.0",
     "@fortawesome/fontawesome-free": "^5.13.0",
-    "@patternfly/react-core": "^4.40.4",
-    "@patternfly/react-table": "^4.12.1",
+    "@patternfly/react-core": "^4.47.0",
+    "@patternfly/react-table": "^4.16.7",
     "@react-keycloak/web": "^2.1.4",
     "@types/react-router-dom": "^5.1.5",
     "@types/react-syntax-highlighter": "^11.0.4",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "@types/react-router-dom": "^5.1.5",
     "@types/react-syntax-highlighter": "^11.0.4",
     "data-urls": "^2.0.0",
-    "json-data-validator": "^2.1.0",
+    "json-data-validator": "^2.3.0",
     "keycloak-js": "^11.0.1",
     "moment": "^2.27.0",
     "react": "^16.13.1",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -41,8 +41,9 @@ export class App extends Component<{}, UpsAdminState> {
       alert: (
         messageOrError: string | Error,
         details?: string[],
-        type?: AlertVariant
-      ) => addAlert(messageOrError, this, details, type),
+        type?: AlertVariant,
+        timeout?: number
+      ) => addAlert(messageOrError, this, details, type, timeout),
       alerts: [],
       selectVariant: this.selectVariant,
       authConfig: {},
@@ -106,29 +107,32 @@ export class App extends Component<{}, UpsAdminState> {
     return (
       <ApplicationListContext.Provider value={this.state}>
         <AlertGroup isToast>
-          {this.state.alerts.map(({ key, variant, title, details }) => (
-            <Alert
-              isLiveRegion
-              variant={AlertVariant[variant]}
-              title={title}
-              actionClose={
-                <AlertActionCloseButton
-                  title={title}
-                  variantLabel={`${variant} alert`}
-                  onClose={() => removeAlert(key, this)}
-                />
-              }
-              key={key}
-            >
-              {details.length === 0 ? null : (
-                <ul>
-                  {details.map(detail => (
-                    <p>{detail}</p>
-                  ))}
-                </ul>
-              )}
-            </Alert>
-          ))}
+          {this.state.alerts.map(
+            ({ key, variant, title, details, timeout }) => (
+              <Alert
+                isLiveRegion
+                variant={AlertVariant[variant]}
+                title={title}
+                timeout={timeout}
+                actionClose={
+                  <AlertActionCloseButton
+                    title={title}
+                    variantLabel={`${variant} alert`}
+                    onClose={() => removeAlert(key, this)}
+                  />
+                }
+                key={key}
+              >
+                {details.length === 0 ? null : (
+                  <ul>
+                    {details.map(detail => (
+                      <p>{detail}</p>
+                    ))}
+                  </ul>
+                )}
+              </Alert>
+            )
+          )}
         </AlertGroup>
         <Page
           header={<Header />}

--- a/src/application/ApplicationDetail/InstallationsCount.tsx
+++ b/src/application/ApplicationDetail/InstallationsCount.tsx
@@ -1,0 +1,90 @@
+import { PushApplication, Variant } from '@aerogear/unifiedpush-admin-client';
+import { Text, TextVariants } from '@patternfly/react-core';
+import React, {
+  Component,
+  ReactNode,
+  useContext,
+  useEffect,
+  useState,
+} from 'react';
+import { UpsClientFactory } from '../../utils/UpsClientFactory';
+import {
+  ApplicationListContext,
+  ContextInterface,
+} from '../../context/Context';
+
+interface Props {
+  variant: Variant;
+  app: PushApplication;
+  autoRefresh?: boolean;
+  onNewInstallation?: (app: PushApplication) => void;
+  deviceInstalledComponent?: ReactNode;
+  deviceNotInstalledComponent?: ReactNode;
+}
+
+export function InstallationCount(props: Props) {
+  const context = useContext<ContextInterface>(ApplicationListContext);
+  const [variant, setVariant] = useState<Variant>(props.variant);
+
+  const defaultDeviceInstalledComponent = (
+    <Text
+      style={{ paddingLeft: 20, color: '#999' }}
+      component={TextVariants.small}
+    >
+      {`${variant.metadata?.deviceCount} Device${
+        variant.metadata?.deviceCount! > 1 ? 's' : ''
+      }`}
+    </Text>
+  );
+
+  const defaultNoInstallationComponent = (
+    <Text
+      style={{ paddingLeft: 20, color: '#999' }}
+      component={TextVariants.small}
+    >
+      <i style={{ paddingRight: 5 }} className="fas fa-ban" />
+      No installation yet
+    </Text>
+  );
+
+  useEffect(() => {
+    if (props.autoRefresh) {
+      const interval = setInterval(async () => {
+        const updatedApp = (
+          await UpsClientFactory.getUpsClient()
+            .applications.search()
+            .withApplicationID(props.app.pushApplicationID)
+            .execute()
+        ).list[0];
+        const update = updatedApp.variants?.find(
+          v => v.variantID === props.variant.variantID
+        );
+
+        if (
+          update?.metadata?.deviceCount !== 0 &&
+          variant.metadata?.deviceCount !== update?.metadata?.deviceCount
+        ) {
+          const upd = async () => {
+            await context.selectVariant(update);
+            if (props.onNewInstallation) {
+              props.onNewInstallation(updatedApp);
+            }
+          };
+          upd();
+        }
+        setVariant({ ...variant, ...update });
+      }, 3000);
+      return () => clearInterval(interval);
+    } else {
+      return () => {};
+    }
+  }, []);
+
+  return (
+    <>
+      {!variant.metadata?.deviceCount
+        ? props.deviceNotInstalledComponent || defaultNoInstallationComponent
+        : props.deviceInstalledComponent || defaultDeviceInstalledComponent}
+    </>
+  );
+}

--- a/src/application/ApplicationDetail/SenderAPI.tsx
+++ b/src/application/ApplicationDetail/SenderAPI.tsx
@@ -27,6 +27,7 @@ import {
   ApplicationListContext,
   ContextInterface,
 } from '../../context/Context';
+import { SenderApiSnippets } from './senderapi-snippets-panel/SenderApiSnippets';
 
 interface State {
   refreshSecret: boolean;
@@ -106,93 +107,7 @@ export class SenderAPI extends Component<Props, State> {
         <Alert variant="warning" title="Keep this info secure!">
           Never expose your Master Secret or Application ID publicly.
         </Alert>
-        <Tabs
-          style={{ marginTop: 20 }}
-          activeKey={this.state.activeTab}
-          isBox={false}
-          onSelect={(evt, key) => onTabSelect(key as string)}
-        >
-          <Tab eventKey={'java-sender-api'} title="Java Sender API">
-            <Title headingLevel={'h1'}>Set up Java UPS Sender API</Title>
-            <Text component={'small'}>
-              First add{' '}
-              <code className={'code'}>unifiedpush-java-client.jar</code> as a{' '}
-              <a href={getLink('sender-api-java')}>
-                dependency to your Java project
-              </a>
-              .
-              <p>
-                Then use the following snippet in your Java code to enable push
-                notification sending.
-              </p>
-            </Text>
-            <CodeSnippet
-              app={this.props.app}
-              language={'java'}
-              snippet={java_snippet}
-            />
-            <Text component={'small'}>
-              Read more on the details of the{' '}
-              <a href={getLink('sender-api-java')}>
-                Java UPS Sender API in documentation
-              </a>
-              .
-              <p>
-                If you have questions about this process,{' '}
-                <a href={getLink('sender-api-java')}>
-                  visit the documentation for full step by step explanation
-                </a>
-                .
-              </p>
-            </Text>
-          </Tab>
-          <Tab eventKey={'node-sender-api'} title="Node.js Sender API">
-            <Title headingLevel={'h1'}>Set up Node.js Sender API</Title>
-            <Text component={'small'}>
-              First add <code className={'code'}>unifiedpush-node-sender</code>{' '}
-              as a{' '}
-              <a href={getLink('sender-api-nodejs')}>
-                dependency to your project
-              </a>
-              .
-              <p>
-                Then use the following snippet in your Node.js code to enable
-                push notification sending.
-              </p>
-            </Text>
-            <CodeSnippet
-              app={this.props.app}
-              language={'javascript'}
-              snippet={node_snippet}
-            />
-            <Text component={'small'}>
-              Read more on the details of the{' '}
-              <a href={getLink('sender-api-nodejs')}>
-                Node.js UPS Sender API in documentation
-              </a>
-              .
-            </Text>
-          </Tab>
-          <Tab eventKey={'rest-sender-api'} title="REST Sender API (with CURL)">
-            <Title headingLevel={'h1'}>
-              Use UPS REST Sender API (with CURL)
-            </Title>
-            <Text component={'small'}>
-              If none of the official client libs suit you or you just want to
-              simply try out the notification sending, you can use the REST API
-              directly.
-              <p>
-                Run the following <code className={'code'}>curl</code> command
-                in a shell to send a notification to UPS server.
-              </p>
-            </Text>
-            <CodeSnippet
-              app={this.props.app}
-              language={'bash'}
-              snippet={curl_snippet}
-            />
-          </Tab>
-        </Tabs>
+        <SenderApiSnippets app={this.props.app} />
       </>
     );
   };

--- a/src/application/ApplicationDetail/panels/VariantDetails.tsx
+++ b/src/application/ApplicationDetail/panels/VariantDetails.tsx
@@ -32,12 +32,6 @@ interface Props {
   variant: Variant;
 }
 
-interface State {
-  refreshSecret?: boolean;
-  editNetworkOptions?: boolean;
-  docLinks?: UpsConfig;
-}
-
 export function VariantDetails(props: Props) {
   const [refreshSecret, openRefreshSecretDialog] = useState<boolean>(false);
   const [docLinks, setDocLinks] = useState<UpsConfig>({});

--- a/src/application/ApplicationDetail/panels/VariantItem.tsx
+++ b/src/application/ApplicationDetail/panels/VariantItem.tsx
@@ -26,6 +26,7 @@ import {
   ApplicationListContext,
   ContextInterface,
 } from '../../../context/Context';
+import { InstallationCount } from '../InstallationsCount';
 
 interface Props {
   app: PushApplication;
@@ -65,17 +66,7 @@ export function VariantItem(props: Props) {
               <DataListCell key="primary content">
                 <div id={'cell-' + props.variant.id}>
                   {props.variant.name}
-                  <Text
-                    style={{ paddingLeft: 20, color: '#999' }}
-                    component={TextVariants.small}
-                  >
-                    <i style={{ paddingRight: 5 }} className="fas fa-ban" />
-                    {!props.variant.metadata?.deviceCount
-                      ? 'No installation yet'
-                      : `${props.variant.metadata?.deviceCount} Device${
-                          props.variant.metadata?.deviceCount > 1 ? 's' : ''
-                        }`}
-                  </Text>
+                  <InstallationCount variant={props.variant} app={props.app} />
                 </div>
               </DataListCell>,
               <DataListCell key="buttons">

--- a/src/application/ApplicationDetail/senderapi-snippets-panel/SenderApiSnippets.tsx
+++ b/src/application/ApplicationDetail/senderapi-snippets-panel/SenderApiSnippets.tsx
@@ -1,0 +1,100 @@
+import { Tab, Tabs, Text } from '@patternfly/react-core';
+import { Title } from '../../../common/Title';
+import { CodeSnippet } from '../CodeSnippet';
+import { snippet as java_snippet } from '../snippets/sender/java';
+import { snippet as node_snippet } from '../snippets/sender/node';
+import { snippet as curl_snippet } from '../snippets/sender/curl';
+import React, { useContext, useState } from 'react';
+import { PushApplication } from '@aerogear/unifiedpush-admin-client';
+import { getLink as _getLink } from '../../../utils/DocLinksUtils';
+import {
+  ApplicationListContext,
+  ContextInterface,
+} from '../../../context/Context';
+
+interface Props {
+  app: PushApplication;
+}
+
+export function SenderApiSnippets(props: Props) {
+  const context = useContext<ContextInterface>(ApplicationListContext);
+  const [activeTab, setActiveTab] = useState<string>('java-sender-api');
+
+  const getLink = (key: string) => _getLink(context.upsConfig, key);
+
+  return (
+    <Tabs
+      style={{ marginTop: 20 }}
+      activeKey={activeTab}
+      isBox={false}
+      onSelect={(evt, key) => setActiveTab(key as string)}
+    >
+      <Tab eventKey={'java-sender-api'} title="Java Sender API">
+        <Title headingLevel={'h1'}>Set up Java UPS Sender API</Title>
+        <Text component={'small'}>
+          First add <code className={'code'}>unifiedpush-java-client.jar</code>{' '}
+          as a{' '}
+          <a href={getLink('sender-api-java')}>
+            dependency to your Java project
+          </a>
+          .
+          <p>
+            Then use the following snippet in your Java code to enable push
+            notification sending.
+          </p>
+        </Text>
+        <CodeSnippet app={props.app} language={'java'} snippet={java_snippet} />
+        <Text component={'small'}>
+          Read more on the details of the{' '}
+          <a href={getLink('sender-api-java')}>
+            Java UPS Sender API in documentation
+          </a>
+          .
+          <p>
+            If you have questions about this process,{' '}
+            <a href={getLink('sender-api-java')}>
+              visit the documentation for full step by step explanation
+            </a>
+            .
+          </p>
+        </Text>
+      </Tab>
+      <Tab eventKey={'node-sender-api'} title="Node.js Sender API">
+        <Title headingLevel={'h1'}>Set up Node.js Sender API</Title>
+        <Text component={'small'}>
+          First add <code className={'code'}>unifiedpush-node-sender</code> as a{' '}
+          <a href={getLink('sender-api-nodejs')}>dependency to your project</a>.
+          <p>
+            Then use the following snippet in your Node.js code to enable push
+            notification sending.
+          </p>
+        </Text>
+        <CodeSnippet
+          app={props.app}
+          language={'javascript'}
+          snippet={node_snippet}
+        />
+        <Text component={'small'}>
+          Read more on the details of the{' '}
+          <a href={getLink('sender-api-nodejs')}>
+            Node.js UPS Sender API in documentation
+          </a>
+          .
+        </Text>
+      </Tab>
+      <Tab eventKey={'rest-sender-api'} title="REST Sender API (with CURL)">
+        <Title headingLevel={'h1'}>Use UPS REST Sender API (with CURL)</Title>
+        <Text component={'small'}>
+          If none of the official client libs suit you or you just want to
+          simply try out the notification sending, you can use the REST API
+          directly.
+          <p>
+            Run the following <code className={'code'}>curl</code> command in a
+            shell to send a notification to UPS server.
+          </p>
+        </Text>
+        <CodeSnippet app={props.app} language={'bash'} snippet={curl_snippet} />
+      </Tab>
+    </Tabs>
+  );
+}

--- a/src/application/VariantForms/WebpushVariantForm.tsx
+++ b/src/application/VariantForms/WebpushVariantForm.tsx
@@ -79,8 +79,25 @@ export class WebpushVariantForm extends Component<Props, State> {
       .withField('webpushAlias')
       .validate(
         RuleBuilder.required()
-          .withErrorMessage('Please enter a mailto or URL address')
+          .withErrorMessage('Please enter a valid URL or mailto address')
           .build()
+      )
+      .validate(
+        RuleBuilder.composite
+          .any()
+          .withSubRule(
+            RuleBuilder.matches(
+              '^mailto: ?(?:[a-z0-9!#$%&\'*+\\/=?^_`{|}~-]+(?:\\.[a-z0-9!#$%&\'*+\\/=?^_`{|}~-]+)*|"(?:[\x01-\x08\x0b\x0c\x0e-\x1f\x21\x23-\x5b\x5d-\x7f]|\\\\[\x01-\x09\x0b\x0c\x0e-\x7f])*")@(?:(?:[a-z0-9](?:[a-z0-9-]*[a-z0-9])?\\.)+[a-z0-9](?:[a-z0-9-]*[a-z0-9])?|\\[(?:(?:(2(5[0-5]|[0-4][0-9])|1[0-9][0-9]|[1-9]?[0-9]))\\.){3}(?:(2(5[0-5]|[0-4][0-9])|1[0-9][0-9]|[1-9]?[0-9])|[a-z0-9-]*[a-z0-9]:(?:[\x01-\x08\x0b\x0c\x0e-\x1f\x21-\x5a\x53-\x7f]|\\\\[\x01-\x09\x0b\x0c\x0e-\x7f])+)\\])$'
+            )
+          )
+          .withSubRule(
+            RuleBuilder.isValidUrl()
+              .requireTld(true)
+              .requireHost(true)
+              .requireProtocol(true)
+              .build()
+          )
+          .build('Please enter a valid URL or mailto address')
       )
       .build();
 

--- a/src/application/crud/CreateVariantPage.tsx
+++ b/src/application/crud/CreateVariantPage.tsx
@@ -27,7 +27,7 @@ interface State {
 
 interface Props {
   app?: PushApplication;
-  close?: () => void;
+  onFinished: () => void;
 }
 
 export class CreateVariantPage extends Component<Props, State> {
@@ -70,7 +70,7 @@ export class CreateVariantPage extends Component<Props, State> {
                 open={this.state.variantSelectionForm}
                 close={() => this.setState({ variantSelectionForm: false })}
                 app={this.props.app}
-                onFinished={onNext}
+                onFinished={this.props.onFinished}
               />
             )}
           </WizardContextConsumer>

--- a/src/application/wizard/CreateApplicationWizard.tsx
+++ b/src/application/wizard/CreateApplicationWizard.tsx
@@ -43,12 +43,16 @@ export class CreateApplicationWizard extends Component<Props, State> {
     const context = this.context as ContextInterface;
     const { stepIdReached } = this.state;
 
-    const moveNext = async (
+    const move = async (
       nextId: number,
       onNext: () => void,
       stateUpdate?: Partial<State>
     ) => {
-      await this.setState({ ...stateUpdate, stepIdReached: nextId });
+      await this.setState({
+        ...stateUpdate,
+        stepIdReached:
+          nextId > this.state.stepIdReached ? nextId : this.state.stepIdReached,
+      });
       onNext();
     };
 
@@ -57,7 +61,7 @@ export class CreateApplicationWizard extends Component<Props, State> {
         {({ onNext }) => (
           <CreateApplicationPage
             onFinished={async application =>
-              moveNext(2, onNext, { app: application })
+              move(2, onNext, { app: application })
             }
           />
         )}
@@ -68,7 +72,7 @@ export class CreateApplicationWizard extends Component<Props, State> {
         {({ onNext }) => (
           <CreateVariantPage
             app={this.state.app!}
-            onFinished={() => moveNext(3, onNext)}
+            onFinished={() => move(3, onNext)}
           />
         )}
       </WizardContextConsumer>
@@ -80,17 +84,23 @@ export class CreateApplicationWizard extends Component<Props, State> {
           <SetupPage
             app={this.state.app!}
             variant={context.selectedVariant!}
-            onFinished={onNext}
+            onFinished={() => move(4, onNext)}
           />
         )}
       </WizardContextConsumer>
     );
 
     const sendTestNotificationPage = (
-      <SendTestNotificationPage
-        app={this.state.app!}
-        variant={context.selectedVariant!}
-      />
+      <WizardContextConsumer>
+        {({ onNext, onBack }) => (
+          <SendTestNotificationPage
+            app={this.state.app!}
+            variant={context.selectedVariant!}
+            onFinished={() => move(5, onNext)}
+            onBack={() => move(4, onBack)}
+          />
+        )}
+      </WizardContextConsumer>
     );
 
     const setupSenderAPI = (
@@ -99,7 +109,7 @@ export class CreateApplicationWizard extends Component<Props, State> {
           <SetupSenderAPI
             app={this.state.app!}
             variant={context.selectedVariant!}
-            onFinished={onNext}
+            onFinished={() => move(6, onNext)}
           />
         )}
       </WizardContextConsumer>
@@ -116,38 +126,41 @@ export class CreateApplicationWizard extends Component<Props, State> {
         id: 1,
         name: 'Create your first Application',
         component: createAppPage,
+        canJumpTo: true,
         nextButtonText: 'Next',
       },
       {
         id: 2,
         name: 'Create Application Variant',
         component: createVariantPage,
-        canJumpTo: stepIdReached >= 20,
+        canJumpTo: stepIdReached >= 2,
         nextButtonText: 'Next',
       },
       {
         id: 3,
         name: 'Mobile device: Set up variant',
         component: setupPage,
-        canJumpTo: stepIdReached >= 30,
+        canJumpTo: stepIdReached >= 3,
         nextButtonText: 'Next',
       } as WizardStep,
       {
         id: 4,
         name: 'Test! Send notification',
         component: sendTestNotificationPage,
-        canJumpTo: stepIdReached >= 40,
+        canJumpTo: stepIdReached >= 3,
         nextButtonText: 'Next',
       } as WizardStep,
       {
         id: 5,
         name: 'Backend: Set up sender API',
         component: setupSenderAPI,
+        canJumpTo: stepIdReached >= 2,
         nextButtonText: 'Next',
       },
       {
         id: 6,
         name: 'Well done!',
+        canJumpTo: stepIdReached >= 2,
         component: finalPage,
       },
     ];

--- a/src/application/wizard/SendTestNotificationPage.tsx
+++ b/src/application/wizard/SendTestNotificationPage.tsx
@@ -1,0 +1,179 @@
+import {
+  AlertVariant,
+  Button,
+  ButtonVariant,
+  Page,
+  Split,
+  SplitItem,
+  Text,
+  TextArea,
+  TextContent,
+  TextVariants,
+  WizardContextConsumer,
+} from '@patternfly/react-core';
+import { InstallationCount } from '../ApplicationDetail/InstallationsCount';
+import React, { useContext, useState } from 'react';
+import {
+  ApplicationListContext,
+  ContextInterface,
+} from '../../context/Context';
+import { PushApplication, Variant } from '@aerogear/unifiedpush-admin-client';
+import { getLink as _getLink } from '../../utils/DocLinksUtils';
+import { CheckIcon } from '@patternfly/react-icons';
+import { UpsClientFactory } from '../../utils/UpsClientFactory';
+
+interface Props {
+  app: PushApplication;
+  variant: Variant;
+}
+
+export function SendTestNotificationPage(props: Props) {
+  const context = useContext<ContextInterface>(ApplicationListContext);
+  const [variantReady, setVariantReady] = useState<boolean>(
+    (props.variant.metadata?.deviceCount || 0) > 0
+  );
+  const [testMessage, setTestMessage] = useState<string>(
+    `Hello! This is my first notification to ${props.variant.name}`
+  );
+
+  const getLink = (key: string) => _getLink(context.upsConfig, key);
+  const getIcon = () => {
+    switch (props.variant.type) {
+      case 'android':
+        return 'fab fa-android fa-3x muted';
+      case 'ios':
+      case 'ios_token':
+        return 'fab fa-apple fa-3x muted';
+      case 'web_push':
+        return 'fab fa-chrome fa-3x muted';
+      default:
+        return '';
+    }
+  };
+
+  const buildVariantContent = (
+    <>
+      <Text component={TextVariants.p}>
+        <b>Build your app!</b> you need a recipient to send the test
+        notification. You can go back to get instructions on how to build your
+        app or skip this and continue with the wizard.
+      </Text>
+      <Text component={TextVariants.p}>
+        You can always
+        <Text component={TextVariants.a}> Skip the wizard </Text> altogether if
+        you want.
+      </Text>
+    </>
+  );
+
+  const variantReadyContent = (
+    <Text component={TextVariants.p}>
+      <b>Excellent!</b> Now lets test by sending a notification and see if
+      everything adds up.
+    </Text>
+  );
+
+  const sendTestMessage = async () => {
+    const agSender = require('unifiedpush-node-sender');
+
+    try {
+      const client = await agSender({
+        url: UpsClientFactory.getUPSServerURL().trim(),
+        applicationId: props.app.pushApplicationID,
+        masterSecret: props.app.masterSecret,
+      });
+
+      await client.sender.send(
+        {
+          alert: testMessage,
+          priority: 'normal',
+        },
+        {}
+      );
+      context.alert(
+        'Test message sent successfully',
+        [],
+        AlertVariant.success,
+        8000
+      );
+    } catch (err) {
+      context.alert(err);
+    }
+  };
+
+  return (
+    <>
+      <Page>
+        <TextContent>
+          <Split style={{ alignItems: 'center' }}>
+            <SplitItem>
+              <i className={getIcon()} />
+            </SplitItem>
+            <SplitItem>
+              <Text component={TextVariants.h1}>{`${props.app.name} :`}</Text>
+            </SplitItem>
+            <SplitItem>
+              <InstallationCount
+                variant={props.variant}
+                app={props.app}
+                autoRefresh={!variantReady}
+                onNewInstallation={() => setVariantReady(true)}
+                deviceInstalledComponent={
+                  <Text
+                    style={{ paddingLeft: 20, color: 'green' }}
+                    component={TextVariants.small}
+                  >
+                    <b>
+                      <CheckIcon /> Successful installation
+                    </b>
+                  </Text>
+                }
+              />
+            </SplitItem>
+          </Split>
+          {variantReady ? variantReadyContent : buildVariantContent}
+        </TextContent>
+      </Page>
+      <Text component={TextVariants.p}>
+        <b>Message</b>
+      </Text>
+      <TextArea
+        disabled={!variantReady}
+        defaultValue={`Hello! This is my first notification to ${props.variant.name}`}
+        onChange={value => setTestMessage(value)}
+      />
+      <WizardContextConsumer>
+        {({ onNext, onBack }) => {
+          if (variantReady) {
+            return (
+              <Button
+                className={'setupPageButton'}
+                variant="primary"
+                onClick={async () => {
+                  await sendTestMessage();
+                  onNext();
+                }}
+              >
+                Send Push Notification And Continue
+              </Button>
+            );
+          }
+          return (
+            <>
+              <Button
+                className={'setupPageButton'}
+                variant="primary"
+                onClick={onBack}
+              >
+                Back To Variant Set Up
+              </Button>
+              <Button variant={ButtonVariant.link} onClick={onNext}>
+                Skip This Step
+              </Button>
+            </>
+          );
+        }}
+      </WizardContextConsumer>
+    </>
+  );
+}

--- a/src/application/wizard/SendTestNotificationPage.tsx
+++ b/src/application/wizard/SendTestNotificationPage.tsx
@@ -9,7 +9,6 @@ import {
   TextArea,
   TextContent,
   TextVariants,
-  WizardContextConsumer,
 } from '@patternfly/react-core';
 import { InstallationCount } from '../ApplicationDetail/InstallationsCount';
 import React, { useContext, useState } from 'react';
@@ -18,13 +17,14 @@ import {
   ContextInterface,
 } from '../../context/Context';
 import { PushApplication, Variant } from '@aerogear/unifiedpush-admin-client';
-import { getLink as _getLink } from '../../utils/DocLinksUtils';
 import { CheckIcon } from '@patternfly/react-icons';
 import { UpsClientFactory } from '../../utils/UpsClientFactory';
 
 interface Props {
   app: PushApplication;
   variant: Variant;
+  onFinished: () => void;
+  onBack: () => void;
 }
 
 export function SendTestNotificationPage(props: Props) {
@@ -36,7 +36,6 @@ export function SendTestNotificationPage(props: Props) {
     `Hello! This is my first notification to ${props.variant.name}`
   );
 
-  const getLink = (key: string) => _getLink(context.upsConfig, key);
   const getIcon = () => {
     switch (props.variant.type) {
       case 'android':
@@ -101,6 +100,37 @@ export function SendTestNotificationPage(props: Props) {
     }
   };
 
+  const content = () => {
+    if (variantReady) {
+      return (
+        <Button
+          className={'setupPageButton'}
+          variant="primary"
+          onClick={async () => {
+            await sendTestMessage();
+            props.onFinished();
+          }}
+        >
+          Send Push Notification And Continue
+        </Button>
+      );
+    }
+    return (
+      <>
+        <Button
+          className={'setupPageButton'}
+          variant="primary"
+          onClick={props.onBack}
+        >
+          Back To Variant Set Up
+        </Button>
+        <Button variant={ButtonVariant.link} onClick={props.onFinished}>
+          Skip This Step
+        </Button>
+      </>
+    );
+  };
+
   return (
     <>
       <Page>
@@ -142,38 +172,7 @@ export function SendTestNotificationPage(props: Props) {
         defaultValue={`Hello! This is my first notification to ${props.variant.name}`}
         onChange={value => setTestMessage(value)}
       />
-      <WizardContextConsumer>
-        {({ onNext, onBack }) => {
-          if (variantReady) {
-            return (
-              <Button
-                className={'setupPageButton'}
-                variant="primary"
-                onClick={async () => {
-                  await sendTestMessage();
-                  onNext();
-                }}
-              >
-                Send Push Notification And Continue
-              </Button>
-            );
-          }
-          return (
-            <>
-              <Button
-                className={'setupPageButton'}
-                variant="primary"
-                onClick={onBack}
-              >
-                Back To Variant Set Up
-              </Button>
-              <Button variant={ButtonVariant.link} onClick={onNext}>
-                Skip This Step
-              </Button>
-            </>
-          );
-        }}
-      </WizardContextConsumer>
+      {content()}
     </>
   );
 }

--- a/src/application/wizard/SendTestNotificationPage.tsx
+++ b/src/application/wizard/SendTestNotificationPage.tsx
@@ -67,7 +67,7 @@ export function SendTestNotificationPage(props: Props) {
 
   const variantReadyContent = (
     <Text component={TextVariants.p}>
-      <b>Excellent!</b> Now lets test by sending a notification and see if
+      <b>Excellent!</b> Now let's test by sending a notification and see if
       everything adds up.
     </Text>
   );

--- a/src/application/wizard/SetupPage.tsx
+++ b/src/application/wizard/SetupPage.tsx
@@ -8,6 +8,9 @@ import {
   TextList,
   TextListItem,
   TextListVariants,
+  Split,
+  SplitItem,
+  WizardContextConsumer,
 } from '@patternfly/react-core';
 import {
   PushApplication,
@@ -15,6 +18,7 @@ import {
   WebPushVariant,
   IOSVariant,
   IOSTokenVariant,
+  Variant,
 } from '@aerogear/unifiedpush-admin-client';
 import {
   ApplicationListContext,
@@ -25,10 +29,11 @@ import { WebPushCodeSnippets } from '../ApplicationDetail/panels/web_push/WebPus
 import { IOSCertCodeSnippets } from '../ApplicationDetail/panels/ios_cert/iOSCertCodeSnippets';
 import { IOSTokenCodeSnippets } from '../ApplicationDetail/panels/ios_token/iOSTokenCodeSnippets';
 import { getLink as _getLink } from '../../utils/DocLinksUtils';
+import { InstallationCount } from '../ApplicationDetail/InstallationsCount';
 
 interface Props {
   app: PushApplication;
-  variant: AndroidVariant;
+  variant: Variant;
   onFinished: () => void;
 }
 
@@ -37,34 +42,48 @@ export class SetupPage extends Component<Props> {
     const context = this.context as ContextInterface;
     const getLink = (key: string) => _getLink(context.upsConfig, key);
 
+    const getIcon = () => {
+      switch (this.props.variant.type) {
+        case 'android':
+          return 'fab fa-android fa-3x muted';
+        case 'ios':
+        case 'ios_token':
+          return 'fab fa-apple fa-3x muted';
+        case 'web_push':
+          return 'fab fa-chrome fa-3x muted';
+        default:
+          return '';
+      }
+    };
+
     const getCodeSnippet = () => {
-      switch (context.selectedVariant?.type) {
+      switch (this.props.variant.type) {
         case 'android':
           return (
             <AndroidCodeSnippets
               app={this.props.app}
-              variant={context.selectedVariant! as AndroidVariant}
+              variant={this.props.variant as AndroidVariant}
             />
           );
         case 'web_push':
           return (
             <WebPushCodeSnippets
               app={this.props.app}
-              variant={context.selectedVariant! as WebPushVariant}
+              variant={this.props.variant as WebPushVariant}
             />
           );
         case 'ios':
           return (
             <IOSCertCodeSnippets
               app={this.props.app}
-              variant={context.selectedVariant! as IOSVariant}
+              variant={this.props.variant as IOSVariant}
             />
           );
         case 'ios_token':
           return (
             <IOSTokenCodeSnippets
               app={this.props.app}
-              variant={context.selectedVariant! as IOSTokenVariant}
+              variant={this.props.variant as IOSTokenVariant}
             />
           );
         default:
@@ -76,7 +95,24 @@ export class SetupPage extends Component<Props> {
       <>
         <Page>
           <TextContent>
-            <Text component={TextVariants.h1}>{`${this.props.app.name}`}</Text>
+            <Split style={{ alignItems: 'center' }}>
+              <SplitItem>
+                <i className={getIcon()} />
+              </SplitItem>
+              <SplitItem>
+                <Text
+                  component={TextVariants.h1}
+                >{`${this.props.app.name} :`}</Text>
+              </SplitItem>
+              <SplitItem>
+                <InstallationCount
+                  variant={this.props.variant}
+                  app={this.props.app}
+                  autoRefresh={true}
+                  onNewInstallation={this.props.onFinished}
+                />
+              </SplitItem>
+            </Split>
             <Text component={TextVariants.p}>
               We are half way there! Use the code snippet below to{' '}
               <Text
@@ -109,9 +145,7 @@ export class SetupPage extends Component<Props> {
               Next we are going to send a test notification. Make sure you {''}
               <Text
                 component={TextVariants.a}
-                href={getLink(
-                  `build-and-deploy-${context.selectedVariant?.type}`
-                )}
+                href={getLink(`build-and-deploy-${this.props.variant.type}`)}
               >
                 build or deploy your app
               </Text>
@@ -119,13 +153,17 @@ export class SetupPage extends Component<Props> {
             </Text>
           </TextContent>
         </Page>
-        <Button
-          className={'setupPageButton'}
-          variant="primary"
-          onClick={() => {}}
-        >
-          Next
-        </Button>
+        <WizardContextConsumer>
+          {({ onNext }) => (
+            <Button
+              className={'setupPageButton'}
+              variant="primary"
+              onClick={onNext}
+            >
+              Next
+            </Button>
+          )}
+        </WizardContextConsumer>
       </>
     );
   }

--- a/src/application/wizard/SetupSenderAPI.tsx
+++ b/src/application/wizard/SetupSenderAPI.tsx
@@ -1,0 +1,67 @@
+import {
+  Button,
+  ButtonVariant,
+  Page,
+  Text,
+  TextContent,
+  TextList,
+  TextListItem,
+  TextListItemVariants,
+  TextListVariants,
+} from '@patternfly/react-core';
+import React from 'react';
+import { PushApplication, Variant } from '@aerogear/unifiedpush-admin-client';
+import { UpsClientFactory } from '../../utils/UpsClientFactory';
+import { Secret } from '../../common/Secret';
+import { SenderApiSnippets } from '../ApplicationDetail/senderapi-snippets-panel/SenderApiSnippets';
+
+interface Props {
+  app: PushApplication;
+  variant: Variant;
+  onFinished: () => void;
+}
+
+export function SetupSenderAPI(props: Props) {
+  return (
+    <>
+      <Page>
+        <TextContent>
+          <Text component={'h1'}>
+            <b>Backend: </b>Set up sender API
+          </Text>
+          <Text component={'small'}>
+            <b>Last step!</b> Now that your mobile device is set up, lets make
+            your backend server send notifications to this UnifiedPush Server
+            using UPS Sender API:
+          </Text>
+        </TextContent>
+        <TextContent style={{ marginTop: 20, marginBottom: 20 }}>
+          <TextList component={TextListVariants.dl}>
+            <TextListItem component={TextListItemVariants.dt}>
+              Server URL
+            </TextListItem>
+            <TextListItem component={TextListItemVariants.dd}>
+              {UpsClientFactory.getUPSServerURL()}
+            </TextListItem>
+            <TextListItem component={TextListItemVariants.dt}>
+              Application ID
+            </TextListItem>
+            <TextListItem component={TextListItemVariants.dd}>
+              {props.app.pushApplicationID}
+            </TextListItem>
+            <TextListItem component={TextListItemVariants.dt}>
+              Master Secret
+            </TextListItem>
+            <TextListItem component={TextListItemVariants.dd}>
+              <Secret text={props.app.masterSecret} />
+            </TextListItem>
+          </TextList>
+        </TextContent>
+      </Page>
+      <SenderApiSnippets app={props.app} />
+      <Button variant={ButtonVariant.primary} onClick={props.onFinished}>
+        Next
+      </Button>
+    </>
+  );
+}

--- a/src/application/wizard/SetupSenderAPI.tsx
+++ b/src/application/wizard/SetupSenderAPI.tsx
@@ -30,7 +30,7 @@ export function SetupSenderAPI(props: Props) {
             <b>Backend: </b>Set up sender API
           </Text>
           <Text component={'small'}>
-            <b>Last step!</b> Now that your mobile device is set up, lets make
+            <b>Last step!</b> Now that your mobile device is set up, let's make
             your backend server send notifications to this UnifiedPush Server
             using UPS Sender API:
           </Text>

--- a/src/application/wizard/WizardFinalPage.tsx
+++ b/src/application/wizard/WizardFinalPage.tsx
@@ -1,0 +1,31 @@
+import React from 'react';
+import {
+  Button,
+  EmptyState,
+  EmptyStateBody,
+  EmptyStateIcon,
+  Title,
+} from '@patternfly/react-core';
+import { CheckSquareIcon } from '@patternfly/react-icons';
+
+interface Props {
+  onClose: () => void;
+}
+
+export function WizardFinalPage(props: Props) {
+  return (
+    <EmptyState>
+      <EmptyStateIcon icon={CheckSquareIcon} />
+      <Title headingLevel="h4" size="lg">
+        Congratulations! you have created an app
+      </Title>
+      <EmptyStateBody>
+        Now go ahead and add more variants, send test notifications and create
+        more applications!
+      </EmptyStateBody>
+      <Button variant="primary" onClick={props.onClose}>
+        Close this wizard
+      </Button>
+    </EmptyState>
+  );
+}

--- a/src/context/Context.ts
+++ b/src/context/Context.ts
@@ -18,7 +18,12 @@ export interface UpsAdminState {
   alerts: Alert[];
 
   alert(err: Error): Promise<void>;
-  alert(message: string, details: string[], type: AlertVariant): Promise<void>;
+  alert(
+    message: string,
+    details: string[],
+    type: AlertVariant,
+    timeout?: number
+  ): Promise<void>;
 
   selectVariant: (variant: Variant) => void;
 

--- a/src/utils/Alerts.ts
+++ b/src/utils/Alerts.ts
@@ -7,6 +7,7 @@ export interface Alert {
   title: string;
   variant: AlertVariant;
   details: string[];
+  timeout: boolean;
 }
 
 interface Alerts {
@@ -17,7 +18,8 @@ export const addAlert = async (
   messageOrError: string | Error,
   owner: Component<unknown, Alerts>,
   details?: string[],
-  type?: AlertVariant
+  type?: AlertVariant,
+  timeout?: number
 ): Promise<void> => {
   if (messageOrError instanceof Error) {
     if (messageOrError instanceof UpsError) {
@@ -32,6 +34,7 @@ export const addAlert = async (
             ),
             title: messageOrError.message,
             variant: AlertVariant.danger,
+            timeout: !!timeout,
           },
         ],
       });
@@ -43,6 +46,7 @@ export const addAlert = async (
           details: [],
           title: messageOrError.message,
           variant: AlertVariant.danger,
+          timeout: !!timeout,
         },
       ],
     });
@@ -55,6 +59,7 @@ export const addAlert = async (
         details: details!,
         title: messageOrError,
         variant: type!,
+        timeout: !!timeout,
       },
     ],
   });


### PR DESCRIPTION
## Motivation
Wizard was not complete and was missing sending test message page

## What
* Added auto refresh for the number of installations so that the wizard can automatically discover if the user successfully installed an app
* Added send test notification page to the wizard
* Added setup server api page to the wizard
* Splitted the sender api page into 2 components, so that the snippet part can be reused both in the wizard and in the standard ui
* Added a 'finished' page to the wizard.
